### PR TITLE
Update to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,13 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "audio-blocks"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "num",
@@ -34,21 +34,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cast"
@@ -58,9 +58,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "ciborium"
@@ -91,18 +91,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -110,22 +110,22 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "criterion"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.13.0",
+ "itertools",
  "num-traits",
  "oorandom",
  "plotters",
@@ -139,12 +139,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -174,24 +174,24 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -201,10 +201,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "half"
-version = "2.4.1"
+name = "getrandom"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -212,18 +224,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "itertools"
@@ -236,15 +239,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -252,27 +255,27 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "num"
@@ -337,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -347,15 +350,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "plotters"
@@ -387,21 +390,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
@@ -484,22 +493,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustversion"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -512,18 +527,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -532,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -544,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -555,15 +570,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -578,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "walkdir"
@@ -593,21 +608,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -619,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -629,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -642,15 +667,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -662,8 +690,14 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-sys"
@@ -671,7 +705,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -680,14 +723,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -697,10 +757,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -709,10 +781,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -721,10 +805,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -733,7 +829,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ name = "audio-blocks"
 readme = "README.md"
 repository = "https://github.com/neodsp/audio-blocks"
 rust-version = "1.85.0"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 num = { version = "0.4.3", default-features = false }
 rtsan-standalone = "0.2.0"
 
 [dev-dependencies]
-criterion = "0.6.0"
+criterion = "0.7.0"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This crate offers traits for handling audio data in a generic way, addressing common challenges such as varying channel layouts, conversions between them, and processing different numbers of samples.
 
-It provides `Interleaved`, `Sequential`, and `Planar` block types, allowing you to choose the underlying data storage: owned data, views, and mutable views. Owned blocks allocate data on the heap, while views offer access to data from slices, raw pointers, or other blocks.
+It provides interleaved, sequential, and planar block types, allowing you to choose the underlying data storage: owned data, views, and mutable views. Owned blocks allocate data on the heap, while views offer access to data from slices, raw pointers, or other blocks.
 
 All block types implement the `AudioBlock` and `AudioBlockMut` traits, with mutable blocks providing in-place modification operations.
 
@@ -139,9 +139,9 @@ fn clear(&mut self);
 
 Available types:
 
-* `Interleaved`
-* `Sequential`
-* `Planar`
+* `AudioBlockInterleaved`
+* `AudioBlockSequential`
+* `AudioBlockPlanar`
 
 ```rust,ignore
 fn new(num_channels: u16, num_frames: usize) -> Self;
@@ -154,9 +154,9 @@ fn from_block(block: &impl AudioBlock<S>) -> Self;
 
 Available types:
 
-* `InterleavedView` / `InterleavedViewMut`
-* `SequentialView` / `SequentialViewMut`
-* `PlanarView` / `PlanarViewMut`
+* `AudioBlockInterleavedView` / `AudioBlockInterleavedViewMut`
+* `AudioBlockSequentialView` / `AudioBlockSequentialViewMut`
+* `AudioBlockPlanarView` / `AudioBlockPlanarViewMut`
 
 ```rust,ignore
 fn from_slice(data: &'a [S], num_channels: u16, num_frames: usize) -> Self;
@@ -170,7 +170,7 @@ unsafe fn from_ptr(data: *const S, num_channels: u16, num_frames: usize) -> Self
 unsafe fn from_ptr_limited(data: *const S, num_channels_visible: u16, num_frames_visible: usize, num_channels_allocated: u16, num_frames_allocated: usize) -> Self;
 ```
 
-Planar blocks can only be created from raw pointers using `PlanarPtrAdapter`:
+Planar blocks can only be created from raw pointers using `PlanarPtrAdapter` / `PlanarPtrAdapterMut`:
 
 ```rust,ignore
 let mut adapter = unsafe { PlanarPtrAdapter::<_, 16>::from_ptr(data, num_channels, num_frames) };
@@ -203,8 +203,8 @@ fn process(&mut self, other_block: &mut impl AudioBlock<f32>) {
 
 When iterating using channels or frames, performance is influenced by the block's memory layout.
 
-* For Sequential and Planar layouts, iterating over channels is generally faster.
-* For Interleaved layouts, especially with a high number of channels, iterating over frames might offer better performance.
+* For sequential and planar layouts, iterating over channels is generally faster.
+* For interleaved layouts, especially with a high number of channels, iterating over frames might offer better performance.
 
 Accessing data via `channel_slice` and `frame_slice` isn't significantly faster than direct slice access but can be convenient for SIMD operations or functions requiring slice inputs.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This crate offers traits for handling audio data in a generic way, addressing common challenges such as varying channel layouts, conversions between them, and processing different numbers of samples.
 
-It provides `Interleaved`, `Sequential`, and `Stacked` block types, allowing you to choose the underlying data storage: owned data, views, and mutable views. Owned blocks allocate data on the heap, while views offer access to data from slices, raw pointers, or other blocks.
+It provides `Interleaved`, `Sequential`, and `Planar` block types, allowing you to choose the underlying data storage: owned data, views, and mutable views. Owned blocks allocate data on the heap, while views offer access to data from slices, raw pointers, or other blocks.
 
 All block types implement the `AudioBlock` and `AudioBlockMut` traits, with mutable blocks providing in-place modification operations.
 
@@ -24,7 +24,7 @@ The core problem this crate solves is the diversity of audio data formats:
     * **Terminology:** Described as "planar" or "channels first," emphasizing that all data for one channel precedes the data for the next.
     * **Usage:** Common in Digital Signal Processing (DSP) pipelines where per-channel processing is more straightforward and efficient.
 
-* **Stacked:** `[[ch0, ch0, ch0], [ch1, ch1, ch1]]`
+* **Planar:** `[[ch0, ch0, ch0], [ch1, ch1, ch1]]`
     * **Interpretation:** Each channel has its own distinct buffer or array.
     * **Terminology:** Also known as "planar" or "channels first," but more specifically refers to channel-isolated buffers.
     * **Usage:** Highly prevalent in real-time DSP due to simplified memory access and potential for improved SIMD (Single Instruction, Multiple Data) or vectorization efficiency.
@@ -58,7 +58,7 @@ fn process<F: Float + 'static>(block: &mut impl AudioBlockMut<F>) {
 }
 ```
 
-Accessing audio data is facilitated through iterators like `channels()` and `frames()`. You can also access specific channels or frames using `channel(u16)` and `frame(usize)`, or individual samples with `sample(u16, usize)`. Iterating over frames can be more efficient for interleaved data, while iterating over channels is generally faster for sequential or stacked layouts.
+Accessing audio data is facilitated through iterators like `channels()` and `frames()`. You can also access specific channels or frames using `channel(u16)` and `frame(usize)`, or individual samples with `sample(u16, usize)`. Iterating over frames can be more efficient for interleaved data, while iterating over channels is generally faster for sequential or planar layouts.
 
 ## All Trait Functions
 
@@ -87,7 +87,7 @@ fn frame_slice(&self, frame: usize) -> Option<&[S]>;
 
 /// Views and raw data access
 fn view(&self) -> impl AudioBlock<S>;
-fn raw_data(&self, stacked_ch: Option<u16>) -> &[S];
+fn raw_data(&self, planar_ch: Option<u16>) -> &[S];
 ```
 
 ### `AudioBlockMut`
@@ -115,7 +115,7 @@ fn frame_slice_mut(&mut self, frame: usize) -> Option<&mut [T]>;
 
 /// Views and raw data access
 fn view_mut(&mut self) -> impl AudioBlockMut<S>;
-fn raw_data_mut(&mut self, stacked_ch: Option<u16>) -> &mut [S];
+fn raw_data_mut(&mut self, planar_ch: Option<u16>) -> &mut [S];
 ```
 
 ## Operations
@@ -141,7 +141,7 @@ Available types:
 
 * `Interleaved`
 * `Sequential`
-* `Stacked`
+* `Planar`
 
 ```rust,ignore
 fn new(num_channels: u16, num_frames: usize) -> Self;
@@ -156,7 +156,7 @@ Available types:
 
 * `InterleavedView` / `InterleavedViewMut`
 * `SequentialView` / `SequentialViewMut`
-* `StackedView` / `StackedViewMut`
+* `PlanarView` / `PlanarViewMut`
 
 ```rust,ignore
 fn from_slice(data: &'a [S], num_channels: u16, num_frames: usize) -> Self;
@@ -170,11 +170,11 @@ unsafe fn from_ptr(data: *const S, num_channels: u16, num_frames: usize) -> Self
 unsafe fn from_ptr_limited(data: *const S, num_channels_visible: u16, num_frames_visible: usize, num_channels_allocated: u16, num_frames_allocated: usize) -> Self;
 ```
 
-Stacked blocks can only be created from raw pointers using `StackedPtrAdapter`:
+Planar blocks can only be created from raw pointers using `PlanarPtrAdapter`:
 
 ```rust,ignore
-let mut adapter = unsafe { StackedPtrAdapter::<_, 16>::from_ptr(data, num_channels, num_frames) };
-let block = adapter.stacked_view();
+let mut adapter = unsafe { PlanarPtrAdapter::<_, 16>::from_ptr(data, num_channels, num_frames) };
+let block = adapter.planar_view();
 ```
 
 ## Handling Varying Number of Frames
@@ -203,7 +203,7 @@ fn process(&mut self, other_block: &mut impl AudioBlock<f32>) {
 
 When iterating using channels or frames, performance is influenced by the block's memory layout.
 
-* For Sequential and Stacked layouts, iterating over channels is generally faster.
+* For Sequential and Planar layouts, iterating over channels is generally faster.
 * For Interleaved layouts, especially with a high number of channels, iterating over frames might offer better performance.
 
 Accessing data via `channel_slice` and `frame_slice` isn't significantly faster than direct slice access but can be convenient for SIMD operations or functions requiring slice inputs.

--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ fn frame(&self, frame: usize) -> impl Iterator<Item = &S>;
 fn frames(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_;
 fn frame_slice(&self, frame: usize) -> Option<&[S]>;
 
-/// Views and raw data access
+/// View and raw data access
 fn view(&self) -> impl AudioBlock<S>;
-fn raw_data(&self, planar_ch: Option<u16>) -> &[S];
+fn raw_data_interleaved(&self) -> Option<&[S]>;
+fn raw_data_planar(&self, ch: u16) -> Option<&[S]>;
+fn raw_data_sequential(&self) -> Option<&[S]>;
 ```
 
 ### `AudioBlockMut`
@@ -113,9 +115,11 @@ fn frame_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S>;
 fn frames_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_;
 fn frame_slice_mut(&mut self, frame: usize) -> Option<&mut [T]>;
 
-/// Views and raw data access
+/// View and raw data access
 fn view_mut(&mut self) -> impl AudioBlockMut<S>;
-fn raw_data_mut(&mut self, planar_ch: Option<u16>) -> &mut [S];
+fn raw_data_interleaved_mut(&mut self) -> Option<&mut [S]>;
+fn raw_data_planar_mut(&mut self, ch: u16) -> Option<&mut [S]>;
+fn raw_data_sequential_mut(&mut self) -> Option<&mut [S]>;
 ```
 
 ## Operations
@@ -197,7 +201,7 @@ fn process(&mut self, other_block: &mut impl AudioBlock<f32>) {
 }
 ```
 
-> **Warning:** Accessing `raw_data` can be unsafe because it provides access to all contained samples, including those that are not intended to be visible.
+> **Warning:** Accessing raw_data can be dangerous because it provides access to all contained samples, including those that are not intended to be visible.
 
 ## Performance Considerations
 

--- a/benches/blocks.rs
+++ b/benches/blocks.rs
@@ -1,20 +1,23 @@
-use audio_blocks::{interleaved::Interleaved, ops::Ops, planar::Planar, sequential::Sequential};
+use audio_blocks::{
+    interleaved::AudioBlockInterleaved, ops::Ops, planar::AudioBlockPlanar,
+    sequential::AudioBlockSequential,
+};
 use criterion::{Criterion, criterion_group, criterion_main};
 
 pub fn bench_three_types(c: &mut Criterion, num_channels: u16, num_frames: usize) {
-    let mut block = Interleaved::<f32>::new(num_channels, num_frames);
+    let mut block = AudioBlockInterleaved::<f32>::new(num_channels, num_frames);
     c.bench_function(
         &format!("for each interleaved {num_channels}ch {num_frames}fr"),
         |b| b.iter(|| block.for_each(|v| *v *= 2.0)),
     );
 
-    let mut block = Sequential::<f32>::new(num_channels, num_frames);
+    let mut block = AudioBlockSequential::<f32>::new(num_channels, num_frames);
     c.bench_function(
         &format!("for each sequential {num_channels}ch {num_frames}fr"),
         |b| b.iter(|| block.for_each(|v| *v *= 2.0)),
     );
 
-    let mut block = Planar::<f32>::new(num_channels, num_frames);
+    let mut block = AudioBlockPlanar::<f32>::new(num_channels, num_frames);
     c.bench_function(
         &format!("for each planar {num_channels}ch {num_frames}fr"),
         |b| b.iter(|| block.for_each(|v| *v *= 2.0)),

--- a/benches/blocks.rs
+++ b/benches/blocks.rs
@@ -1,4 +1,4 @@
-use audio_blocks::{interleaved::Interleaved, ops::Ops, sequential::Sequential, stacked::Stacked};
+use audio_blocks::{interleaved::Interleaved, ops::Ops, planar::Planar, sequential::Sequential};
 use criterion::{Criterion, criterion_group, criterion_main};
 
 pub fn bench_three_types(c: &mut Criterion, num_channels: u16, num_frames: usize) {
@@ -14,9 +14,9 @@ pub fn bench_three_types(c: &mut Criterion, num_channels: u16, num_frames: usize
         |b| b.iter(|| block.for_each(|v| *v *= 2.0)),
     );
 
-    let mut block = Stacked::<f32>::new(num_channels, num_frames);
+    let mut block = Planar::<f32>::new(num_channels, num_frames);
     c.bench_function(
-        &format!("for each stacked {num_channels}ch {num_frames}fr"),
+        &format!("for each planar {num_channels}ch {num_frames}fr"),
         |b| b.iter(|| block.for_each(|v| *v *= 2.0)),
     );
 }

--- a/src/interleaved/mod.rs
+++ b/src/interleaved/mod.rs
@@ -4,6 +4,6 @@ mod view;
 mod view_mut;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use owned::Interleaved;
-pub use view::InterleavedView;
-pub use view_mut::InterleavedViewMut;
+pub use owned::AudioBlockInterleaved;
+pub use view::AudioBlockInterleavedView;
+pub use view_mut::AudioBlockInterleavedViewMut;

--- a/src/interleaved/owned.rs
+++ b/src/interleaved/owned.rs
@@ -32,7 +32,7 @@ use crate::{
 /// block.channel_mut(0).for_each(|v| *v = 0.0);
 /// block.channel_mut(1).for_each(|v| *v = 1.0);
 ///
-/// assert_eq!(block.raw_data(None), &[0.0, 1.0, 0.0, 1.0, 0.0, 1.0]);
+/// assert_eq!(block.raw_data_interleaved().unwrap(), &[0.0, 1.0, 0.0, 1.0, 0.0, 1.0]);
 /// ```
 pub struct AudioBlockInterleaved<S: Sample> {
     data: Box<[S]>,
@@ -225,8 +225,8 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn raw_data(&self, _: Option<u16>) -> &[S] {
-        &self.data
+    fn raw_data_interleaved(&self) -> Option<&[S]> {
+        Some(&self.data)
     }
 }
 
@@ -329,8 +329,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn raw_data_mut(&mut self, _: Option<u16>) -> &mut [S] {
-        &mut self.data
+    fn raw_data_interleaved_mut(&mut self) -> Option<&mut [S]> {
+        Some(&mut self.data)
     }
 }
 
@@ -359,7 +359,7 @@ mod tests {
         }
 
         assert_eq!(
-            block.raw_data(None),
+            block.raw_data_interleaved().unwrap(),
             &[0.0, 5.0, 1.0, 6.0, 2.0, 7.0, 3.0, 8.0, 4.0, 9.0]
         );
     }
@@ -707,13 +707,18 @@ mod tests {
 
         assert_eq!(block.layout(), crate::BlockLayout::Interleaved);
 
+        assert_eq!(block.raw_data_sequential(), None);
+        assert_eq!(block.raw_data_sequential_mut(), None);
+        assert_eq!(block.raw_data_planar(0), None);
+        assert_eq!(block.raw_data_planar_mut(0), None);
+
         assert_eq!(
-            block.raw_data(None),
+            block.raw_data_interleaved().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
 
         assert_eq!(
-            block.raw_data_mut(None),
+            block.raw_data_interleaved_mut().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
     }

--- a/src/interleaved/owned.rs
+++ b/src/interleaved/owned.rs
@@ -8,7 +8,7 @@ use std::{boxed::Box, vec, vec::Vec};
 #[cfg(all(feature = "std", feature = "alloc"))]
 use std::{boxed::Box, vec, vec::Vec};
 
-use super::{view::InterleavedView, view_mut::InterleavedViewMut};
+use super::{view::AudioBlockInterleavedView, view_mut::AudioBlockInterleavedViewMut};
 use crate::{
     AudioBlock, AudioBlockMut, Sample,
     iter::{StridedSampleIter, StridedSampleIterMut},
@@ -26,15 +26,15 @@ use crate::{
 /// ```
 /// use audio_blocks::*;
 ///
-/// let block = Interleaved::new(2, 3);
-/// let mut block = Interleaved::from_block(&block);
+/// let block = AudioBlockInterleaved::new(2, 3);
+/// let mut block = AudioBlockInterleaved::from_block(&block);
 ///
 /// block.channel_mut(0).for_each(|v| *v = 0.0);
 /// block.channel_mut(1).for_each(|v| *v = 1.0);
 ///
 /// assert_eq!(block.raw_data(None), &[0.0, 1.0, 0.0, 1.0, 0.0, 1.0]);
 /// ```
-pub struct Interleaved<S: Sample> {
+pub struct AudioBlockInterleaved<S: Sample> {
     data: Box<[S]>,
     num_channels: u16,
     num_frames: usize,
@@ -42,8 +42,8 @@ pub struct Interleaved<S: Sample> {
     num_frames_allocated: usize,
 }
 
-impl<S: Sample> Interleaved<S> {
-    /// Creates a new [`Interleaved`] audio block with the specified dimensions.
+impl<S: Sample> AudioBlockInterleaved<S> {
+    /// Creates a new interleaved audio block with the specified dimensions.
     ///
     /// Allocates memory for a new interleaved audio block with exactly the specified
     /// number of channels and frames. The block is initialized with the default value
@@ -74,7 +74,7 @@ impl<S: Sample> Interleaved<S> {
         }
     }
 
-    /// Creates a new [`Interleaved`] audio block by copying data from another [`AudioBlock`].
+    /// Creates a new audio block by copying data from another [`AudioBlock`].
     ///
     /// Converts any [`AudioBlock`] implementation to an interleaved format by iterating
     /// through each frame of the source block and copying its samples. The new block
@@ -101,7 +101,7 @@ impl<S: Sample> Interleaved<S> {
     }
 }
 
-impl<S: Sample> AudioBlock<S> for Interleaved<S> {
+impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     #[nonblocking]
     fn num_channels(&self) -> u16 {
         self.num_channels
@@ -210,7 +210,7 @@ impl<S: Sample> AudioBlock<S> for Interleaved<S> {
 
     #[nonblocking]
     fn view(&self) -> impl AudioBlock<S> {
-        InterleavedView::from_slice_limited(
+        AudioBlockInterleavedView::from_slice_limited(
             &self.data,
             self.num_channels,
             self.num_frames,
@@ -230,7 +230,7 @@ impl<S: Sample> AudioBlock<S> for Interleaved<S> {
     }
 }
 
-impl<S: Sample> AudioBlockMut<S> for Interleaved<S> {
+impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     #[nonblocking]
     fn set_active_num_channels(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
@@ -319,7 +319,7 @@ impl<S: Sample> AudioBlockMut<S> for Interleaved<S> {
 
     #[nonblocking]
     fn view_mut(&mut self) -> impl AudioBlockMut<S> {
-        InterleavedViewMut::from_slice_limited(
+        AudioBlockInterleavedViewMut::from_slice_limited(
             &mut self.data,
             self.num_channels,
             self.num_frames,
@@ -339,11 +339,11 @@ mod tests {
     use rtsan_standalone::no_sanitize_realtime;
 
     use super::*;
-    use crate::sequential::SequentialView;
+    use crate::sequential::AudioBlockSequentialView;
 
     #[test]
     fn test_samples() {
-        let mut block = Interleaved::<f32>::new(2, 5);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 5);
 
         let num_frames = block.num_frames();
         for ch in 0..block.num_channels() {
@@ -366,7 +366,7 @@ mod tests {
 
     #[test]
     fn test_channel() {
-        let mut block = Interleaved::<f32>::new(2, 5);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 5);
 
         let channel = block.channel(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 0.0, 0.0, 0.0, 0.0]);
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn test_channels() {
-        let mut block = Interleaved::<f32>::new(2, 5);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 5);
 
         let mut channels_iter = block.channels();
         let channel = channels_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn test_frame() {
-        let mut block = Interleaved::<f32>::new(2, 5);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 5);
 
         for i in 0..block.num_frames() {
             let frame = block.frame(i).copied().collect::<Vec<_>>();
@@ -454,7 +454,7 @@ mod tests {
 
     #[test]
     fn test_frames() {
-        let mut block = Interleaved::<f32>::new(2, 5);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 5);
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames();
         for _ in 0..num_frames {
@@ -492,11 +492,12 @@ mod tests {
 
     #[test]
     fn test_from_slice() {
-        let block = Interleaved::<f32>::from_block(&InterleavedView::from_slice(
-            &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-            2,
-            5,
-        ));
+        let block =
+            AudioBlockInterleaved::<f32>::from_block(&AudioBlockInterleavedView::from_slice(
+                &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                2,
+                5,
+            ));
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated(), 2);
         assert_eq!(block.num_frames(), 5);
@@ -518,11 +519,12 @@ mod tests {
 
     #[test]
     fn test_view() {
-        let block = Interleaved::<f32>::from_block(&InterleavedView::from_slice(
-            &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-            2,
-            5,
-        ));
+        let block =
+            AudioBlockInterleaved::<f32>::from_block(&AudioBlockInterleavedView::from_slice(
+                &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                2,
+                5,
+            ));
         let view = block.view();
         assert_eq!(
             view.channel(0).copied().collect::<Vec<_>>(),
@@ -536,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_view_mut() {
-        let mut block = Interleaved::<f32>::new(2, 5);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 5);
         {
             let mut view = block.view_mut();
             view.channel_mut(0)
@@ -559,13 +561,13 @@ mod tests {
 
     #[test]
     fn test_from_block() {
-        let block = SequentialView::<f32>::from_slice(
+        let block = AudioBlockSequentialView::<f32>::from_slice(
             &[0.0, 2.0, 4.0, 6.0, 8.0, 1.0, 3.0, 5.0, 7.0, 9.0],
             2,
             5,
         );
 
-        let block = Interleaved::<f32>::from_block(&block);
+        let block = AudioBlockInterleaved::<f32>::from_block(&block);
 
         assert_eq!(
             block.channel(0).copied().collect::<Vec<_>>(),
@@ -579,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_resize() {
-        let mut block = Interleaved::<f32>::new(3, 10);
+        let mut block = AudioBlockInterleaved::<f32>::new(3, 10);
         assert_eq!(block.num_channels(), 3);
         assert_eq!(block.num_frames(), 10);
         assert_eq!(block.num_channels_allocated(), 3);
@@ -616,7 +618,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_resize_channels() {
-        let mut block = Interleaved::<f32>::new(2, 10);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
         block.set_active_size(3, 10);
     }
 
@@ -624,7 +626,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_resize_frames() {
-        let mut block = Interleaved::<f32>::new(2, 10);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
         block.set_active_size(2, 11);
     }
 
@@ -632,7 +634,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_channel() {
-        let mut block = Interleaved::<f32>::new(2, 10);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
         block.set_active_size(1, 10);
         let _ = block.channel(1);
     }
@@ -641,7 +643,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_frame() {
-        let mut block = Interleaved::<f32>::new(2, 10);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
         block.set_active_size(2, 5);
         let _ = block.frame(5);
     }
@@ -650,7 +652,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_channel_mut() {
-        let mut block = Interleaved::<f32>::new(2, 10);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
         block.set_active_size(1, 10);
         let _ = block.channel_mut(1);
     }
@@ -659,14 +661,14 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_frame_mut() {
-        let mut block = Interleaved::<f32>::new(2, 10);
+        let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
         block.set_active_size(2, 5);
         let _ = block.frame_mut(5);
     }
 
     #[test]
     fn test_slice() {
-        let mut block = Interleaved::<f32>::new(3, 6);
+        let mut block = AudioBlockInterleaved::<f32>::new(3, 6);
         block.set_active_size(2, 5);
         assert!(block.channel_slice(0).is_none());
 
@@ -682,7 +684,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
-        let mut block = Interleaved::<f32>::new(3, 6);
+        let mut block = AudioBlockInterleaved::<f32>::new(3, 6);
         block.set_active_size(2, 5);
         block.frame_slice(5);
     }
@@ -691,7 +693,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
-        let mut block = Interleaved::<f32>::new(3, 6);
+        let mut block = AudioBlockInterleaved::<f32>::new(3, 6);
         block.set_active_size(2, 5);
         block.frame_slice(5);
     }
@@ -699,8 +701,9 @@ mod tests {
     #[test]
     fn test_raw_data() {
         let data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let mut block =
-            Interleaved::<f32>::from_block(&InterleavedView::<f32>::from_slice(&data, 2, 5));
+        let mut block = AudioBlockInterleaved::<f32>::from_block(
+            &AudioBlockInterleavedView::<f32>::from_slice(&data, 2, 5),
+        );
 
         assert_eq!(block.layout(), crate::BlockLayout::Interleaved);
 

--- a/src/interleaved/owned.rs
+++ b/src/interleaved/owned.rs
@@ -123,6 +123,11 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Interleaved
+    }
+
+    #[nonblocking]
     fn sample(&self, channel: u16, frame: usize) -> S {
         assert!(channel < self.num_channels);
         assert!(frame < self.num_frames);
@@ -217,11 +222,6 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
             self.num_channels_allocated,
             self.num_frames_allocated,
         )
-    }
-
-    #[nonblocking]
-    fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Interleaved
     }
 
     #[nonblocking]

--- a/src/interleaved/view.rs
+++ b/src/interleaved/view.rs
@@ -18,7 +18,7 @@ use crate::{AudioBlock, Sample, iter::StridedSampleIter};
 ///
 /// let data = vec![0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
 ///
-/// let block = InterleavedView::from_slice(&data, 2, 3);
+/// let block = AudioBlockInterleavedView::from_slice(&data, 2, 3);
 ///
 /// block.channel(0).for_each(|&v| assert_eq!(v, 0.0));
 /// block.channel(1).for_each(|&v| assert_eq!(v, 1.0));
@@ -262,8 +262,8 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedView<'_, S> {
     }
 
     #[nonblocking]
-    fn raw_data(&self, _: Option<u16>) -> &[S] {
-        self.data
+    fn raw_data_interleaved(&self) -> Option<&[S]> {
+        Some(self.data)
     }
 }
 
@@ -476,8 +476,11 @@ mod tests {
 
         assert_eq!(block.layout(), crate::BlockLayout::Interleaved);
 
+        assert_eq!(block.raw_data_sequential(), None);
+        assert_eq!(block.raw_data_planar(0), None);
+
         assert_eq!(
-            block.raw_data(None),
+            block.raw_data_interleaved().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
     }

--- a/src/interleaved/view_mut.rs
+++ b/src/interleaved/view_mut.rs
@@ -268,8 +268,8 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn raw_data(&self, _: Option<u16>) -> &[S] {
-        self.data
+    fn raw_data_interleaved(&self) -> Option<&[S]> {
+        Some(self.data)
     }
 }
 
@@ -374,8 +374,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn raw_data_mut(&mut self, _: Option<u16>) -> &mut [S] {
-        self.data
+    fn raw_data_interleaved_mut(&mut self) -> Option<&mut [S]> {
+        Some(self.data)
     }
 }
 
@@ -404,7 +404,7 @@ mod tests {
         }
 
         assert_eq!(
-            block.raw_data(None),
+            block.raw_data_interleaved().unwrap(),
             &[0.0, 5.0, 1.0, 6.0, 2.0, 7.0, 3.0, 8.0, 4.0, 9.0]
         );
     }
@@ -716,13 +716,18 @@ mod tests {
 
         assert_eq!(block.layout(), crate::BlockLayout::Interleaved);
 
+        assert_eq!(block.raw_data_sequential(), None);
+        assert_eq!(block.raw_data_sequential_mut(), None);
+        assert_eq!(block.raw_data_planar(0), None);
+        assert_eq!(block.raw_data_planar_mut(0), None);
+
         assert_eq!(
-            block.raw_data(None),
+            block.raw_data_interleaved().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
 
         assert_eq!(
-            block.raw_data_mut(None),
+            block.raw_data_interleaved_mut().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
     }

--- a/src/interleaved/view_mut.rs
+++ b/src/interleaved/view_mut.rs
@@ -172,6 +172,11 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Interleaved
+    }
+
+    #[nonblocking]
     fn sample(&self, channel: u16, frame: usize) -> S {
         assert!(channel < self.num_channels);
         assert!(frame < self.num_frames);
@@ -260,11 +265,6 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
             self.num_channels_allocated,
             self.num_frames_allocated,
         )
-    }
-
-    #[nonblocking]
-    fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Interleaved
     }
 
     #[nonblocking]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,19 +56,19 @@ pub enum BlockLayout {
     /// This layout is common in consumer audio formats and some APIs.
     Interleaved,
 
-    /// All samples from one channel appear consecutively before the next channel.
-    ///
-    /// Format: `[ch0, ch0, ch0, ..., ch1, ch1, ch1, ...]`
-    ///
-    /// Also known as "planar" format in some audio libraries.
-    Sequential,
-
     /// Channels are separated into discrete chunks of memory.
     ///
     /// Format: `[[ch0, ch0, ch0, ...], [ch1, ch1, ch1, ...]]`
     ///
     /// Useful for operations that work on one channel at a time.
     Planar,
+
+    /// All samples from one channel appear consecutively before the next channel.
+    ///
+    /// Format: `[ch0, ch0, ch0, ..., ch1, ch1, ch1, ...]`
+    ///
+    /// Also known as "planar" format in some audio libraries.
+    Sequential,
 }
 
 /// Represents a sample type that can be stored and processed in audio blocks.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,21 +15,21 @@ pub use num::Zero;
 pub use ops::Ops;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use interleaved::Interleaved;
-pub use interleaved::InterleavedView;
-pub use interleaved::InterleavedViewMut;
+pub use interleaved::AudioBlockInterleaved;
+pub use interleaved::AudioBlockInterleavedView;
+pub use interleaved::AudioBlockInterleavedViewMut;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use sequential::Sequential;
-pub use sequential::SequentialView;
-pub use sequential::SequentialViewMut;
+pub use sequential::AudioBlockSequential;
+pub use sequential::AudioBlockSequentialView;
+pub use sequential::AudioBlockSequentialViewMut;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use planar::Planar;
+pub use planar::AudioBlockPlanar;
+pub use planar::AudioBlockPlanarView;
+pub use planar::AudioBlockPlanarViewMut;
 pub use planar::PlanarPtrAdapter;
 pub use planar::PlanarPtrAdapterMut;
-pub use planar::PlanarView;
-pub use planar::PlanarViewMut;
 
 pub mod interleaved;
 mod iter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,20 +210,6 @@ pub trait AudioBlock<S: Sample> {
         None
     }
 
-    /// Provides direct access to the underlying memory as a sequential slice.
-    ///
-    /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range, but it is safe in terms of memory safety.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Some(&[S])` if the block's layout is [`BlockLayout::Sequential`], containing
-    /// sequential data with all allocated channels. Returns `None` if the layout is
-    /// not sequential. Check `block.layout() == BlockLayout::Sequential` before calling.
-    fn raw_data_sequential(&self) -> Option<&[S]> {
-        None
-    }
-
     /// Provides direct access to the underlying memory as a planar slice for a specific channel.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
@@ -240,6 +226,20 @@ pub trait AudioBlock<S: Sample> {
     /// not planar. Check `block.layout() == BlockLayout::Planar` before calling.
     fn raw_data_planar(&self, ch: u16) -> Option<&[S]> {
         let _ = ch;
+        None
+    }
+
+    /// Provides direct access to the underlying memory as a sequential slice.
+    ///
+    /// This function gives access to all allocated data, including any reserved capacity
+    /// beyond the active range, but it is safe in terms of memory safety.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(&[S])` if the block's layout is [`BlockLayout::Sequential`], containing
+    /// sequential data with all allocated channels. Returns `None` if the layout is
+    /// not sequential. Check `block.layout() == BlockLayout::Sequential` before calling.
+    fn raw_data_sequential(&self) -> Option<&[S]> {
         None
     }
 }
@@ -376,20 +376,6 @@ pub trait AudioBlockMut<S: Sample>: AudioBlock<S> {
         None
     }
 
-    /// Provides direct mutable access to the underlying memory as a sequential slice.
-    ///
-    /// This function gives mutable access to all allocated data, including any reserved capacity
-    /// beyond the active range, but it is safe in terms of memory safety.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Some(&mut [S])` if the block's layout is [`BlockLayout::Sequential`], containing
-    /// sequential data with all allocated channels. Returns `None` if the layout is
-    /// not sequential. Check `block.layout() == BlockLayout::Sequential` before calling.
-    fn raw_data_sequential_mut(&mut self) -> Option<&mut [S]> {
-        None
-    }
-
     /// Provides direct mutable access to the underlying memory as a planar slice for a specific channel.
     ///
     /// This function gives mutable access to all allocated data, including any reserved capacity
@@ -406,6 +392,20 @@ pub trait AudioBlockMut<S: Sample>: AudioBlock<S> {
     /// not planar. Check `block.layout() == BlockLayout::Planar` before calling.
     fn raw_data_planar_mut(&mut self, ch: u16) -> Option<&mut [S]> {
         let _ = ch;
+        None
+    }
+
+    /// Provides direct mutable access to the underlying memory as a sequential slice.
+    ///
+    /// This function gives mutable access to all allocated data, including any reserved capacity
+    /// beyond the active range, but it is safe in terms of memory safety.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(&mut [S])` if the block's layout is [`BlockLayout::Sequential`], containing
+    /// sequential data with all allocated channels. Returns `None` if the layout is
+    /// not sequential. Check `block.layout() == BlockLayout::Sequential` before calling.
+    fn raw_data_sequential_mut(&mut self) -> Option<&mut [S]> {
         None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,25 +196,52 @@ pub trait AudioBlock<S: Sample> {
     /// as it returns a lightweight wrapper around the original data.
     fn view(&self) -> impl AudioBlock<S>;
 
-    /// Provides direct access to the underlying memory as a slice.
+    /// Provides direct access to the underlying memory as an interleaved slice.
     ///
-    /// # Safety
+    /// This function gives access to all allocated data, including any reserved capacity
+    /// beyond the active range, but it is safe in terms of memory safety.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(&[S])` if the block's layout is [`BlockLayout::Interleaved`], containing
+    /// interleaved samples across all allocated channels. Returns `None` if the layout is
+    /// not interleaved. Check `block.layout() == BlockLayout::Interleaved` before calling.
+    fn raw_data_interleaved(&self) -> Option<&[S]> {
+        None
+    }
+
+    /// Provides direct access to the underlying memory as a sequential slice.
+    ///
+    /// This function gives access to all allocated data, including any reserved capacity
+    /// beyond the active range, but it is safe in terms of memory safety.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(&[S])` if the block's layout is [`BlockLayout::Sequential`], containing
+    /// sequential data with all allocated channels. Returns `None` if the layout is
+    /// not sequential. Check `block.layout() == BlockLayout::Sequential` before calling.
+    fn raw_data_sequential(&self) -> Option<&[S]> {
+        None
+    }
+
+    /// Provides direct access to the underlying memory as a planar slice for a specific channel.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
     /// beyond the active range, but it is safe in terms of memory safety.
     ///
     /// # Parameters
     ///
-    /// * `planar_ch` - For `Layout::Planar`, specifies which channel to access (required).
-    ///   For other layouts, this parameter is ignored.
+    /// * `ch` - Specifies which channel to access.
     ///
     /// # Returns
     ///
-    /// A slice containing all allocated data. The data format follows the block's layout:
-    /// - For `Interleaved`: returns interleaved samples across all allocated channels
-    /// - For `Sequential`: returns planar data with all allocated channels
-    /// - For `Planar`: returns data for the specified channel only
-    fn raw_data(&self, planar_ch: Option<u16>) -> &[S];
+    /// Returns `Some(&[S])` if the block's layout is [`BlockLayout::Planar`], containing
+    /// data for the specified channel only. Returns `None` if the layout is
+    /// not planar. Check `block.layout() == BlockLayout::Planar` before calling.
+    fn raw_data_planar(&self, ch: u16) -> Option<&[S]> {
+        let _ = ch;
+        None
+    }
 }
 
 /// Extends the [`AudioBlock`] trait with mutable access operations.
@@ -335,23 +362,50 @@ pub trait AudioBlockMut<S: Sample>: AudioBlock<S> {
     /// as it returns a lightweight wrapper around the original data.
     fn view_mut(&mut self) -> impl AudioBlockMut<S>;
 
-    /// Provides direct mutable access to the underlying memory as a slice.
+    /// Provides direct mutable access to the underlying memory as an interleaved slice.
     ///
-    /// # Safety
+    /// This function gives mutable access to all allocated data, including any reserved capacity
+    /// beyond the active range, but it is safe in terms of memory safety.
     ///
-    /// This function gives access to all allocated data, including any reserved capacity
+    /// # Returns
+    ///
+    /// Returns `Some(&mut [S])` if the block's layout is [`BlockLayout::Interleaved`], containing
+    /// interleaved samples across all allocated channels. Returns `None` if the layout is
+    /// not interleaved. Check `block.layout() == BlockLayout::Interleaved` before calling.
+    fn raw_data_interleaved_mut(&mut self) -> Option<&mut [S]> {
+        None
+    }
+
+    /// Provides direct mutable access to the underlying memory as a sequential slice.
+    ///
+    /// This function gives mutable access to all allocated data, including any reserved capacity
+    /// beyond the active range, but it is safe in terms of memory safety.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(&mut [S])` if the block's layout is [`BlockLayout::Sequential`], containing
+    /// sequential data with all allocated channels. Returns `None` if the layout is
+    /// not sequential. Check `block.layout() == BlockLayout::Sequential` before calling.
+    fn raw_data_sequential_mut(&mut self) -> Option<&mut [S]> {
+        None
+    }
+
+    /// Provides direct mutable access to the underlying memory as a planar slice for a specific channel.
+    ///
+    /// This function gives mutable access to all allocated data, including any reserved capacity
     /// beyond the active range, but it is safe in terms of memory safety.
     ///
     /// # Parameters
     ///
-    /// * `planar_ch` - For `BlockLayout::Planar`, specifies which channel to access (required).
-    ///   For other layouts, this parameter is ignored.
+    /// * `ch` - Specifies which channel to access.
     ///
     /// # Returns
     ///
-    /// A mutable slice containing all allocated data. The data format follows the block's layout:
-    /// - For `Interleaved`: returns interleaved samples across all allocated channels
-    /// - For `Sequential`: returns planar data with all allocated channels
-    /// - For `Planar`: returns data for the specified channel only
-    fn raw_data_mut(&mut self, planar_ch: Option<u16>) -> &mut [S];
+    /// Returns `Some(&mut [S])` if the block's layout is [`BlockLayout::Planar`], containing
+    /// data for the specified channel only. Returns `None` if the layout is
+    /// not planar. Check `block.layout() == BlockLayout::Planar` before calling.
+    fn raw_data_planar_mut(&mut self, ch: u16) -> Option<&mut [S]> {
+        let _ = ch;
+        None
+    }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -173,9 +173,9 @@ mod tests {
     use rtsan_standalone::no_sanitize_realtime;
 
     use crate::{
-        interleaved::InterleavedViewMut,
-        planar::PlanarViewMut,
-        sequential::{SequentialView, SequentialViewMut},
+        interleaved::AudioBlockInterleavedViewMut,
+        planar::AudioBlockPlanarViewMut,
+        sequential::{AudioBlockSequentialView, AudioBlockSequentialViewMut},
     };
 
     use super::*;
@@ -183,8 +183,9 @@ mod tests {
     #[test]
     fn test_copy_from() {
         let mut data = [0.0; 15];
-        let mut block = InterleavedViewMut::from_slice(&mut data, 3, 5);
-        let view = SequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 3, 5);
+        let view =
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
         block.copy_from_block_resize(&view);
 
         assert_eq!(block.num_channels(), 2);
@@ -205,8 +206,9 @@ mod tests {
     #[test]
     fn test_copy_from_exact() {
         let mut data = [0.0; 8];
-        let mut block = InterleavedViewMut::from_slice(&mut data, 2, 4);
-        let view = SequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2, 4);
+        let view =
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
         block.copy_from_block(&view);
 
         assert_eq!(block.num_channels(), 2);
@@ -229,8 +231,9 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_copy_data_wrong_channels() {
         let mut data = [0.0; 5];
-        let mut block = InterleavedViewMut::from_slice(&mut data, 1, 5);
-        let view = SequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 1, 5);
+        let view =
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
         block.copy_from_block_resize(&view);
     }
 
@@ -239,8 +242,9 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_copy_data_wrong_frames() {
         let mut data = [0.0; 9];
-        let mut block = InterleavedViewMut::from_slice(&mut data, 3, 3);
-        let view = SequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 3, 3);
+        let view =
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
         block.copy_from_block(&view);
     }
 
@@ -249,8 +253,9 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_copy_data_exact_wrong_channels() {
         let mut data = [0.0; 12];
-        let mut block = InterleavedViewMut::from_slice(&mut data, 3, 4);
-        let view = SequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 3, 4);
+        let view =
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
         block.copy_from_block(&view);
     }
 
@@ -259,15 +264,16 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_copy_data_exact_wrong_frames() {
         let mut data = [0.0; 10];
-        let mut block = InterleavedViewMut::from_slice(&mut data, 2, 5);
-        let view = SequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2, 5);
+        let view =
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
         block.copy_from_block(&view);
     }
 
     #[test]
     fn test_for_each() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
-        let mut block = SequentialViewMut::from_slice(&mut data, 2, 4);
+        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 2, 4);
 
         let mut i = 0;
         let mut c_exp = 0;
@@ -284,7 +290,7 @@ mod tests {
         });
 
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
-        let mut block = InterleavedViewMut::from_slice(&mut data, 2, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2, 4);
 
         let mut i = 0;
         let mut f_exp = 0;
@@ -301,7 +307,7 @@ mod tests {
         });
 
         let mut data = [[0.0, 1.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]];
-        let mut block = PlanarViewMut::from_slice(&mut data);
+        let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
 
         let mut i = 0;
         let mut c_exp = 0;
@@ -321,7 +327,7 @@ mod tests {
     #[test]
     fn test_clear() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
-        let mut block = SequentialViewMut::from_slice(&mut data, 2, 4);
+        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 2, 4);
 
         block.fill_with(1.0);
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -65,7 +65,7 @@ impl<S: Sample, B: AudioBlockMut<S>> Ops<S> for B {
             }
         } else {
             match self.layout() {
-                BlockLayout::Sequential | BlockLayout::Stacked => {
+                BlockLayout::Sequential | BlockLayout::Planar => {
                     for channel in self.channels_mut() {
                         channel.for_each(&mut f);
                     }
@@ -84,7 +84,7 @@ impl<S: Sample, B: AudioBlockMut<S>> Ops<S> for B {
         match self.layout() {
             BlockLayout::Sequential => self.raw_data_mut(None).iter_mut().for_each(&mut f),
             BlockLayout::Interleaved => self.raw_data_mut(None).iter_mut().for_each(&mut f),
-            BlockLayout::Stacked => {
+            BlockLayout::Planar => {
                 for ch in 0..self.num_channels() {
                     self.raw_data_mut(Some(ch)).iter_mut().for_each(&mut f);
                 }
@@ -103,7 +103,7 @@ impl<S: Sample, B: AudioBlockMut<S>> Ops<S> for B {
             }
         } else {
             match self.layout() {
-                BlockLayout::Sequential | BlockLayout::Stacked => {
+                BlockLayout::Sequential | BlockLayout::Planar => {
                     for ch in 0..self.num_channels() {
                         self.channel_mut(ch)
                             .enumerate()
@@ -146,7 +146,7 @@ impl<S: Sample, B: AudioBlockMut<S>> Ops<S> for B {
                         f(channel as u16, frame, sample)
                     });
             }
-            BlockLayout::Stacked => {
+            BlockLayout::Planar => {
                 for ch in 0..self.num_channels() {
                     self.raw_data_mut(Some(ch))
                         .iter_mut()
@@ -174,8 +174,8 @@ mod tests {
 
     use crate::{
         interleaved::InterleavedViewMut,
+        planar::PlanarViewMut,
         sequential::{SequentialView, SequentialViewMut},
-        stacked::StackedViewMut,
     };
 
     use super::*;
@@ -301,7 +301,7 @@ mod tests {
         });
 
         let mut data = [[0.0, 1.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]];
-        let mut block = StackedViewMut::from_slice(&mut data);
+        let mut block = PlanarViewMut::from_slice(&mut data);
 
         let mut i = 0;
         let mut c_exp = 0;

--- a/src/planar/mod.rs
+++ b/src/planar/mod.rs
@@ -4,6 +4,6 @@ mod view;
 mod view_mut;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use owned::Planar;
-pub use view::{PlanarPtrAdapter, PlanarView};
-pub use view_mut::{PlanarPtrAdapterMut, PlanarViewMut};
+pub use owned::AudioBlockPlanar;
+pub use view::{AudioBlockPlanarView, PlanarPtrAdapter};
+pub use view_mut::{AudioBlockPlanarViewMut, PlanarPtrAdapterMut};

--- a/src/planar/mod.rs
+++ b/src/planar/mod.rs
@@ -4,6 +4,6 @@ mod view;
 mod view_mut;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use owned::Stacked;
-pub use view::{StackedPtrAdapter, StackedView};
-pub use view_mut::{StackedPtrAdapterMut, StackedViewMut};
+pub use owned::Planar;
+pub use view::{PlanarPtrAdapter, PlanarView};
+pub use view_mut::{PlanarPtrAdapterMut, PlanarViewMut};

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -29,8 +29,8 @@ use super::{view::AudioBlockPlanarView, view_mut::AudioBlockPlanarViewMut};
 /// block.channel_mut(0).for_each(|v| *v = 0.0);
 /// block.channel_mut(1).for_each(|v| *v = 1.0);
 ///
-/// assert_eq!(block.raw_data(Some(0)), &[0.0, 0.0, 0.0]);
-/// assert_eq!(block.raw_data(Some(1)), &[1.0, 1.0, 1.0]);
+/// assert_eq!(block.raw_data_planar(0).unwrap(), &[0.0, 0.0, 0.0]);
+/// assert_eq!(block.raw_data_planar(1).unwrap(), &[1.0, 1.0, 1.0]);
 /// ```
 pub struct AudioBlockPlanar<S: Sample> {
     data: Box<[Box<[S]>]>,
@@ -203,10 +203,9 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn raw_data(&self, planar_ch: Option<u16>) -> &[S] {
-        let ch = planar_ch.expect("For planar layout channel needs to be provided!");
+    fn raw_data_planar(&self, ch: u16) -> Option<&[S]> {
         assert!(ch < self.num_channels_allocated);
-        unsafe { self.data.get_unchecked(ch as usize) }
+        Some(unsafe { self.data.get_unchecked(ch as usize) })
     }
 }
 
@@ -304,10 +303,9 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn raw_data_mut(&mut self, planar_ch: Option<u16>) -> &mut [S] {
-        let ch = planar_ch.expect("For planar layout channel needs to be provided!");
+    fn raw_data_planar_mut(&mut self, ch: u16) -> Option<&mut [S]> {
         assert!(ch < self.num_channels_allocated);
-        unsafe { self.data.get_unchecked_mut(ch as usize).as_mut() }
+        Some(unsafe { self.data.get_unchecked_mut(ch as usize) })
     }
 }
 
@@ -335,8 +333,14 @@ mod tests {
             }
         }
 
-        assert_eq!(block.raw_data(Some(0)), &[0.0, 1.0, 2.0, 3.0, 4.0]);
-        assert_eq!(block.raw_data(Some(1)), &[5.0, 6.0, 7.0, 8.0, 9.0]);
+        assert_eq!(
+            block.raw_data_planar(0).unwrap(),
+            &[0.0, 1.0, 2.0, 3.0, 4.0]
+        );
+        assert_eq!(
+            block.raw_data_planar(1).unwrap(),
+            &[5.0, 6.0, 7.0, 8.0, 9.0]
+        );
     }
 
     #[test]
@@ -662,10 +666,27 @@ mod tests {
 
         assert_eq!(block.layout(), crate::BlockLayout::Planar);
 
-        assert_eq!(block.raw_data(Some(0)), &[0.0, 2.0, 4.0, 6.0, 8.0]);
-        assert_eq!(block.raw_data(Some(1)), &[1.0, 3.0, 5.0, 7.0, 9.0]);
+        assert_eq!(block.raw_data_interleaved(), None);
+        assert_eq!(block.raw_data_interleaved_mut(), None);
+        assert_eq!(block.raw_data_sequential(), None);
+        assert_eq!(block.raw_data_sequential_mut(), None);
 
-        assert_eq!(block.raw_data_mut(Some(0)), &[0.0, 2.0, 4.0, 6.0, 8.0]);
-        assert_eq!(block.raw_data_mut(Some(1)), &[1.0, 3.0, 5.0, 7.0, 9.0]);
+        assert_eq!(
+            block.raw_data_planar(0).unwrap(),
+            &[0.0, 2.0, 4.0, 6.0, 8.0]
+        );
+        assert_eq!(
+            block.raw_data_planar(1).unwrap(),
+            &[1.0, 3.0, 5.0, 7.0, 9.0]
+        );
+
+        assert_eq!(
+            block.raw_data_planar_mut(0).unwrap(),
+            &[0.0, 2.0, 4.0, 6.0, 8.0]
+        );
+        assert_eq!(
+            block.raw_data_planar_mut(1).unwrap(),
+            &[1.0, 3.0, 5.0, 7.0, 9.0]
+        );
     }
 }

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -117,6 +117,11 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Planar
+    }
+
+    #[nonblocking]
     fn sample(&self, channel: u16, frame: usize) -> S {
         assert!(channel < self.num_channels);
         assert!(frame < self.num_frames);
@@ -195,11 +200,6 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     #[nonblocking]
     fn view(&self) -> impl AudioBlock<S> {
         AudioBlockPlanarView::from_slice_limited(&self.data, self.num_channels, self.num_frames)
-    }
-
-    #[nonblocking]
-    fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Planar
     }
 
     #[nonblocking]

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -1,12 +1,17 @@
-use core::mem::MaybeUninit;
-use rtsan_standalone::nonblocking;
-use std::marker::PhantomData;
+use rtsan_standalone::{blocking, nonblocking};
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::{boxed::Box, vec, vec::Vec};
+#[cfg(all(feature = "std", not(feature = "alloc")))]
+use std::{boxed::Box, vec, vec::Vec};
+#[cfg(all(feature = "std", feature = "alloc"))]
+use std::{boxed::Box, vec, vec::Vec};
 
 use crate::{AudioBlock, AudioBlockMut, Sample};
 
-use super::StackedView;
+use super::{view::PlanarView, view_mut::PlanarViewMut};
 
-/// A mutable view of stacked / separate-channel audio data.
+/// A planar / seperate-channel audio block that owns its data.
 ///
 /// * **Layout:** `[[ch0, ch0, ch0], [ch1, ch1, ch1]]`
 /// * **Interpretation:** Each channel has its own separate buffer or array.
@@ -18,83 +23,79 @@ use super::StackedView;
 /// ```
 /// use audio_blocks::*;
 ///
-/// let mut data = vec![[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]];
+/// let block = Planar::new(2, 3);
+/// let mut block = Planar::from_block(&block);
 ///
-/// let block = StackedViewMut::from_slice(&mut data);
+/// block.channel_mut(0).for_each(|v| *v = 0.0);
+/// block.channel_mut(1).for_each(|v| *v = 1.0);
 ///
-/// block.channel(0).for_each(|&v| assert_eq!(v, 0.0));
-/// block.channel(1).for_each(|&v| assert_eq!(v, 1.0));
+/// assert_eq!(block.raw_data(Some(0)), &[0.0, 0.0, 0.0]);
+/// assert_eq!(block.raw_data(Some(1)), &[1.0, 1.0, 1.0]);
 /// ```
-pub struct StackedViewMut<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> {
-    data: &'a mut [V],
+pub struct Planar<S: Sample> {
+    data: Box<[Box<[S]>]>,
     num_channels: u16,
     num_frames: usize,
     num_channels_allocated: u16,
     num_frames_allocated: usize,
-    _phantom: PhantomData<S>,
 }
 
-impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> StackedViewMut<'a, S, V> {
-    /// Creates a new [`StackedViewMut`] from a mutable slice of stacked audio data.
+impl<S: Sample> Planar<S> {
+    /// Creates a new [`Planar`] audio block with the specified dimensions.
     ///
-    /// # Parameters
-    /// * `data` - The mutable slice containing stacked audio samples (one slice per channel)
+    /// Allocates memory for a new planar audio block with exactly the specified
+    /// number of channels and frames. The block is initialized with the default value
+    /// for the sample type.
+    ///
+    /// Do not use in real-time processes!
+    ///
+    /// # Arguments
+    ///
+    /// * `num_channels` - The number of audio channels
+    /// * `num_frames` - The number of frames per channel
     ///
     /// # Panics
-    /// Panics if the channel slices have different lengths.
-    #[nonblocking]
-    pub fn from_slice(data: &'a mut [V]) -> Self {
-        let num_frames_available = if data.is_empty() {
-            0
-        } else {
-            data[0].as_ref().len()
-        };
-        Self::from_slice_limited(data, data.len() as u16, num_frames_available)
+    ///
+    /// Panics if the multiplication of `num_channels` and `num_frames` would overflow a usize.
+    #[blocking]
+    pub fn new(num_channels: u16, num_frames: usize) -> Self {
+        Self {
+            data: vec![vec![S::zero(); num_frames].into_boxed_slice(); num_channels as usize]
+                .into_boxed_slice(),
+            num_channels,
+            num_frames,
+            num_channels_allocated: num_channels,
+            num_frames_allocated: num_frames,
+        }
     }
 
-    /// Creates a new [`StackedViewMut`] from a mutable slice with limited visibility.
+    /// Creates a new [`Planar`] audio block by copying data from another [`AudioBlock`].
     ///
-    /// This function allows creating a view that exposes only a subset of the allocated channels
-    /// and frames, which is useful for working with a logical section of a larger buffer.
+    /// Converts any [`AudioBlock`] implementation to a planar format by iterating
+    /// through each channel of the source block and copying its samples. The new block
+    /// will have the same dimensions as the source block.
     ///
-    /// # Parameters
-    /// * `data` - The mutable slice containing stacked audio samples (one slice per channel)
-    /// * `num_channels_visible` - Number of audio channels to expose in the view
-    /// * `num_frames_visible` - Number of audio frames to expose in the view
+    /// # Warning
     ///
-    /// # Panics
-    /// * Panics if `num_channels_visible` exceeds the number of channels in `data`
-    /// * Panics if `num_frames_visible` exceeds the length of any channel buffer
-    /// * Panics if channel slices have different lengths
-    #[nonblocking]
-    pub fn from_slice_limited(
-        data: &'a mut [V],
-        num_channels_visible: u16,
-        num_frames_visible: usize,
-    ) -> Self {
-        let num_channels_available = data.len();
-        let num_frames_available = if num_channels_available == 0 {
-            0
-        } else {
-            data[0].as_ref().len()
-        };
-        assert!(num_channels_visible <= num_channels_available as u16);
-        assert!(num_frames_visible <= num_frames_available);
-        data.iter()
-            .for_each(|v| assert_eq!(v.as_ref().len(), num_frames_available));
-
+    /// This function allocates memory and should not be used in real-time audio processing contexts.
+    ///
+    /// # Arguments
+    ///
+    /// * `block` - The source audio block to copy data from
+    #[blocking]
+    pub fn from_block(block: &impl AudioBlock<S>) -> Self {
+        let data: Vec<Box<[S]>> = block.channels().map(|c| c.copied().collect()).collect();
         Self {
-            data,
-            num_channels: num_channels_visible,
-            num_frames: num_frames_visible,
-            num_channels_allocated: num_channels_available as u16,
-            num_frames_allocated: num_frames_available,
-            _phantom: PhantomData,
+            data: data.into_boxed_slice(),
+            num_channels: block.num_channels(),
+            num_frames: block.num_frames(),
+            num_channels_allocated: block.num_channels(),
+            num_frames_allocated: block.num_frames(),
         }
     }
 }
 
-impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for StackedViewMut<'_, S, V> {
+impl<S: Sample> AudioBlock<S> for Planar<S> {
     #[nonblocking]
     fn num_channels(&self) -> u16 {
         self.num_channels
@@ -123,7 +124,6 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for StackedViewMut<'_,
             *self
                 .data
                 .get_unchecked(channel as usize)
-                .as_ref()
                 .get_unchecked(frame)
         }
     }
@@ -134,7 +134,6 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for StackedViewMut<'_,
         unsafe {
             self.data
                 .get_unchecked(channel as usize)
-                .as_ref()
                 .iter()
                 .take(self.num_frames)
         }
@@ -163,26 +162,27 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for StackedViewMut<'_,
         self.data
             .iter()
             .take(self.num_channels as usize)
-            .map(move |channel_data| unsafe { channel_data.as_ref().get_unchecked(frame) })
+            .map(move |channel_data| unsafe { channel_data.get_unchecked(frame) })
     }
 
     #[nonblocking]
-    fn frames(&self) -> impl Iterator<Item = impl Iterator<Item = &'_ S> + '_> + '_ {
+    fn frames(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
-        // `self.data` is the field `&'data [V]`. We get `&'a [V]` from `&'a self`.
-        let data_slice: &[V] = self.data;
+        // Get an immutable slice of the channel boxes: `&[Box<[S]>]`
+        let data_slice: &[Box<[S]>] = &self.data;
 
-        // Assumes the struct/caller guarantees that for all `chan` in `0..num_channels`,
-        // `self.data[chan].as_ref().len() >= num_frames`.
+        // Assumes the struct guarantees that for all `chan` in `0..num_channels`,
+        // `self.data[chan].len() >= num_frames`.
 
         (0..num_frames).map(move |frame_idx| {
-            // For each frame index, create an iterator over the relevant channel views.
+            // For each frame index, create an iterator over the relevant channel boxes.
+            // `data_slice` is captured immutably, which is allowed by nested closures.
             data_slice[..num_channels]
-                .iter() // Yields `&'a V`
-                .map(move |channel_view: &V| {
-                    // Get the immutable slice `&[S]` from the view using AsRef.
-                    let channel_slice: &[S] = channel_view.as_ref();
+                .iter() // Yields `&'a Box<[S]>`
+                .map(move |channel_slice_box| {
+                    // Get the immutable slice `&[S]` from the box.
+                    let channel_slice: &[S] = channel_slice_box;
                     // Access the sample immutably using safe indexing.
                     // Assumes frame_idx is valid based on outer loop and struct invariants.
                     &channel_slice[frame_idx]
@@ -194,23 +194,23 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for StackedViewMut<'_,
 
     #[nonblocking]
     fn view(&self) -> impl AudioBlock<S> {
-        StackedView::from_slice_limited(self.data, self.num_channels, self.num_frames)
+        PlanarView::from_slice_limited(&self.data, self.num_channels, self.num_frames)
     }
 
     #[nonblocking]
     fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Stacked
+        crate::BlockLayout::Planar
     }
 
     #[nonblocking]
-    fn raw_data(&self, stacked_ch: Option<u16>) -> &[S] {
-        let ch = stacked_ch.expect("For stacked layout channel needs to be provided!");
+    fn raw_data(&self, planar_ch: Option<u16>) -> &[S] {
+        let ch = planar_ch.expect("For planar layout channel needs to be provided!");
         assert!(ch < self.num_channels_allocated);
-        unsafe { self.data.get_unchecked(ch as usize).as_ref() }
+        unsafe { self.data.get_unchecked(ch as usize) }
     }
 }
 
-impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for StackedViewMut<'_, S, V> {
+impl<S: Sample> AudioBlockMut<S> for Planar<S> {
     #[nonblocking]
     fn set_active_num_channels(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
@@ -230,7 +230,6 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for StackedViewMut<
         unsafe {
             self.data
                 .get_unchecked_mut(channel as usize)
-                .as_mut()
                 .get_unchecked_mut(frame)
         }
     }
@@ -241,7 +240,6 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for StackedViewMut<
         unsafe {
             self.data
                 .get_unchecked_mut(channel as usize)
-                .as_mut()
                 .iter_mut()
                 .take(self.num_frames)
         }
@@ -268,28 +266,28 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for StackedViewMut<
         self.data
             .iter_mut()
             .take(self.num_channels as usize)
-            .map(move |channel_data| unsafe { channel_data.as_mut().get_unchecked_mut(frame) })
+            .map(move |channel_data| unsafe { channel_data.get_unchecked_mut(frame) })
     }
 
     #[nonblocking]
     fn frames_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
-        let data_slice: &mut [V] = self.data;
-        let data_ptr: *mut [V] = data_slice;
+        let data_slice: &mut [Box<[S]>] = &mut self.data;
+        let data_ptr: *mut [Box<[S]>] = data_slice;
 
         (0..num_frames).map(move |frame_idx| {
             // Re-borrow mutably inside the closure via the raw pointer.
             // Safety: Safe because the outer iterator executes this sequentially per frame.
-            let current_channel_views: &mut [V] = unsafe { &mut *data_ptr };
+            let current_channel_boxes: &mut [Box<[S]>] = unsafe { &mut *data_ptr };
 
-            // Iterate over the relevant channel views up to num_channels.
-            current_channel_views[..num_channels]
-                .iter_mut() // Yields `&mut V`
-                .map(move |channel_view: &mut V| {
-                    // Get the mutable slice `&mut [S]` from the view using AsMut.
-                    let channel_slice: &mut [S] = channel_view.as_mut();
-                    // Access the sample for the current channel view at the current frame index.
+            // Iterate over the relevant channel boxes up to num_channels
+            current_channel_boxes[..num_channels]
+                .iter_mut() // Yields `&'a mut Box<[S]>`
+                .map(move |channel_slice_box| {
+                    // Get the mutable slice `&mut [S]` from the box.
+                    let channel_slice: &mut [S] = channel_slice_box;
+                    // Access the sample for the current channel at the current frame index.
                     // Safety: Relies on `frame_idx < channel_slice.len()`.
                     unsafe { channel_slice.get_unchecked_mut(frame_idx) }
                 })
@@ -298,137 +296,27 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for StackedViewMut<
 
     #[nonblocking]
     fn view_mut(&mut self) -> impl AudioBlockMut<S> {
-        StackedViewMut::from_slice_limited(self.data, self.num_channels, self.num_frames)
+        PlanarViewMut::from_slice_limited(&mut self.data, self.num_channels, self.num_frames)
     }
 
     #[nonblocking]
-    fn raw_data_mut(&mut self, stacked_ch: Option<u16>) -> &mut [S] {
-        let ch = stacked_ch.expect("For stacked layout channel needs to be provided!");
+    fn raw_data_mut(&mut self, planar_ch: Option<u16>) -> &mut [S] {
+        let ch = planar_ch.expect("For planar layout channel needs to be provided!");
         assert!(ch < self.num_channels_allocated);
         unsafe { self.data.get_unchecked_mut(ch as usize).as_mut() }
     }
 }
 
-/// Adapter for creating mutable stacked audio block views from raw pointers.
-///
-/// This adapter provides a safe interface to work with mutable audio data stored in external buffers,
-/// which is common when interfacing with audio APIs or hardware.
-///
-/// # Example
-///
-/// ```
-/// use audio_blocks::*;
-///
-/// // Create sample data for two channels with five frames each
-/// let mut ch1 = vec![0.0f32, 1.0, 2.0, 3.0, 4.0];
-/// let mut ch2 = vec![5.0f32, 6.0, 7.0, 8.0, 9.0];
-///
-/// // Create mutable pointers to the channel data
-/// let mut ptrs = [ch1.as_mut_ptr(), ch2.as_mut_ptr()];
-/// let data = ptrs.as_mut_ptr();
-/// let num_channels = 2u16;
-/// let num_frames = 5;
-///
-/// // Create an adapter from raw pointers to audio channel data
-/// let mut adapter = unsafe { StackedPtrAdapterMut::<f32, 16>::from_ptr(data, num_channels, num_frames) };
-///
-/// // Get a safe mutable view of the audio data
-/// let mut block = adapter.stacked_view_mut();
-///
-/// // Verify the data access works and can be modified
-/// assert_eq!(block.sample(0, 2), 2.0);
-/// assert_eq!(block.sample(1, 3), 8.0);
-/// *block.sample_mut(0, 1) = 10.0; // Modify a sample
-/// ```
-///
-/// # Safety
-///
-/// When creating an adapter from raw pointers, you must ensure that:
-/// - The pointers are valid and properly aligned
-/// - The memory they point to remains valid for the lifetime of the adapter
-/// - The data is not accessed through other pointers during the adapter's lifetime
-/// - The channel count doesn't exceed the adapter's `MAX_CHANNELS` capacity
-pub struct StackedPtrAdapterMut<'a, S: Sample, const MAX_CHANNELS: usize> {
-    data: [MaybeUninit<&'a mut [S]>; MAX_CHANNELS],
-    num_channels: u16,
-}
-
-impl<'a, S: Sample, const MAX_CHANNELS: usize> StackedPtrAdapterMut<'a, S, MAX_CHANNELS> {
-    /// Creates new StackedPtrAdapterNew from raw pointers.
-    ///
-    /// # Safety
-    ///
-    /// - `ptr` must be a valid pointer to an array of pointers
-    /// - The array must contain at least `num_channels` valid pointers
-    /// - Each pointer in the array must point to a valid array of samples with `num_frames` length
-    /// - The pointed memory must remain valid for the lifetime of the returned adapter
-    /// - The data must not be modified through other pointers for the lifetime of the returned adapter
-    #[nonblocking]
-    pub unsafe fn from_ptr(ptrs: *mut *mut S, num_channels: u16, num_frames: usize) -> Self {
-        assert!(
-            num_channels as usize <= MAX_CHANNELS,
-            "num_channels exceeds MAX_CHANNELS"
-        );
-
-        let mut data: [MaybeUninit<&'a mut [S]>; MAX_CHANNELS] =
-            unsafe { MaybeUninit::uninit().assume_init() }; // Or other safe initialization
-
-        // SAFETY: Caller guarantees `ptr` is valid for `num_channels` elements.
-        let ptr_slice: &mut [*mut S] =
-            unsafe { core::slice::from_raw_parts_mut(ptrs, num_channels as usize) };
-
-        for ch in 0..num_channels as usize {
-            // SAFETY: See previous explanation
-            data[ch].write(unsafe { core::slice::from_raw_parts_mut(ptr_slice[ch], num_frames) });
-        }
-
-        Self { data, num_channels }
-    }
-
-    /// Returns a mutable slice of references to the initialized channel data buffers.
-    ///
-    /// This method provides access to the underlying audio data as a slice of mutable slices,
-    /// with each inner slice representing one audio channel.
-    #[inline]
-    pub fn data_slice_mut(&mut self) -> &mut [&'a mut [S]] {
-        let initialized_part: &mut [MaybeUninit<&'a mut [S]>] =
-            &mut self.data[..self.num_channels as usize];
-        unsafe {
-            core::slice::from_raw_parts_mut(
-                initialized_part.as_mut_ptr() as *mut &'a mut [S],
-                self.num_channels as usize,
-            )
-        }
-    }
-
-    /// Creates a safe [`StackedViewMut`] for accessing the audio data.
-    ///
-    /// This provides a convenient way to interact with the audio data through
-    /// the full [`AudioBlockMut`] interface, enabling operations like iterating
-    /// through channels or frames and modifying the underlying audio samples.
-    ///
-    /// # Returns
-    ///
-    /// A [`StackedViewMut`] that provides safe, mutable access to the audio data.
-    #[nonblocking]
-    pub fn stacked_view_mut(&mut self) -> StackedViewMut<'a, S, &mut [S]> {
-        StackedViewMut::from_slice(self.data_slice_mut())
-    }
-}
-
 #[cfg(test)]
 mod tests {
-
     use rtsan_standalone::no_sanitize_realtime;
 
     use super::*;
+    use crate::interleaved::InterleavedView;
 
     #[test]
     fn test_samples() {
-        let mut ch1 = vec![0.0; 5];
-        let mut ch2 = vec![0.0; 5];
-        let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice()];
-        let mut block = StackedViewMut::from_slice(&mut data);
+        let mut block = Planar::<f32>::new(2, 5);
 
         let num_frames = block.num_frames();
         for ch in 0..block.num_channels() {
@@ -443,16 +331,13 @@ mod tests {
             }
         }
 
-        assert_eq!(block.channel_slice(0).unwrap(), &[0.0, 1.0, 2.0, 3.0, 4.0]);
-        assert_eq!(block.channel_slice(1).unwrap(), &[5.0, 6.0, 7.0, 8.0, 9.0]);
+        assert_eq!(block.raw_data(Some(0)), &[0.0, 1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(block.raw_data(Some(1)), &[5.0, 6.0, 7.0, 8.0, 9.0]);
     }
 
     #[test]
     fn test_channel() {
-        let mut ch1 = vec![0.0; 5];
-        let mut ch2 = vec![0.0; 5];
-        let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice()];
-        let mut block = StackedViewMut::from_slice(&mut data);
+        let mut block = Planar::<f32>::new(2, 5);
 
         let channel = block.channel(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 0.0, 0.0, 0.0, 0.0]);
@@ -476,10 +361,7 @@ mod tests {
 
     #[test]
     fn test_channels() {
-        let mut ch1 = vec![0.0; 5];
-        let mut ch2 = vec![0.0; 5];
-        let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice()];
-        let mut block = StackedViewMut::from_slice(&mut data);
+        let mut block = Planar::<f32>::new(2, 5);
 
         let mut channels_iter = block.channels();
         let channel = channels_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -514,10 +396,7 @@ mod tests {
 
     #[test]
     fn test_frame() {
-        let mut ch1 = vec![0.0; 5];
-        let mut ch2 = vec![0.0; 5];
-        let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice()];
-        let mut block = StackedViewMut::from_slice(&mut data);
+        let mut block = Planar::<f32>::new(2, 5);
 
         for i in 0..block.num_frames() {
             let frame = block.frame(i).copied().collect::<Vec<_>>();
@@ -546,11 +425,7 @@ mod tests {
 
     #[test]
     fn test_frames() {
-        let mut ch1 = vec![0.0; 10];
-        let mut ch2 = vec![0.0; 10];
-        let mut ch3 = vec![0.0; 10];
-        let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice(), ch3.as_mut_slice()];
-        let mut block = StackedViewMut::from_slice(&mut data);
+        let mut block = Planar::<f32>::new(3, 6);
         block.set_active_size(2, 5);
 
         let num_frames = block.num_frames;
@@ -589,11 +464,16 @@ mod tests {
     }
 
     #[test]
-    fn test_from_vec() {
-        let mut vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let block = StackedViewMut::from_slice(&mut vec);
+    fn test_from_block() {
+        let block = Planar::<f32>::from_block(&InterleavedView::from_slice(
+            &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+            2,
+            5,
+        ));
         assert_eq!(block.num_channels(), 2);
+        assert_eq!(block.num_channels_allocated(), 2);
         assert_eq!(block.num_frames(), 5);
+        assert_eq!(block.num_frames_allocated(), 5);
         assert_eq!(
             block.channel(0).copied().collect::<Vec<_>>(),
             vec![0.0, 2.0, 4.0, 6.0, 8.0]
@@ -611,8 +491,11 @@ mod tests {
 
     #[test]
     fn test_view() {
-        let mut vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let block = StackedViewMut::from_slice(&mut vec);
+        let block = Planar::<f32>::from_block(&InterleavedView::from_slice(
+            &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+            2,
+            5,
+        ));
         let view = block.view();
         assert_eq!(
             view.channel(0).copied().collect::<Vec<_>>(),
@@ -626,9 +509,7 @@ mod tests {
 
     #[test]
     fn test_view_mut() {
-        let mut data = vec![vec![0.0; 5]; 2];
-        let mut block = StackedViewMut::from_slice(&mut data);
-
+        let mut block = Planar::<f32>::new(2, 5);
         {
             let mut view = block.view_mut();
             view.channel_mut(0)
@@ -650,19 +531,33 @@ mod tests {
     }
 
     #[test]
-    fn test_limited() {
-        let mut data = vec![vec![0.0; 4]; 3];
-
-        let mut block = StackedViewMut::from_slice_limited(&mut data, 2, 3);
-
-        assert_eq!(block.num_channels(), 2);
-        assert_eq!(block.num_frames(), 3);
-        assert_eq!(block.num_channels_allocated, 3);
-        assert_eq!(block.num_frames_allocated, 4);
+    fn test_resize() {
+        let mut block = Planar::<f32>::new(3, 10);
+        assert_eq!(block.num_channels(), 3);
+        assert_eq!(block.num_frames(), 10);
+        assert_eq!(block.num_channels_allocated(), 3);
+        assert_eq!(block.num_frames_allocated(), 10);
 
         for i in 0..block.num_channels() {
-            assert_eq!(block.channel(i).count(), 3);
-            assert_eq!(block.channel_mut(i).count(), 3);
+            assert_eq!(block.channel(i).count(), 10);
+            assert_eq!(block.channel_mut(i).count(), 10);
+        }
+        for i in 0..block.num_frames() {
+            assert_eq!(block.frame(i).count(), 3);
+            assert_eq!(block.frame_mut(i).count(), 3);
+        }
+
+        block.set_active_size(3, 10);
+        block.set_active_size(2, 5);
+
+        assert_eq!(block.num_channels(), 2);
+        assert_eq!(block.num_frames(), 5);
+        assert_eq!(block.num_channels_allocated(), 3);
+        assert_eq!(block.num_frames_allocated(), 10);
+
+        for i in 0..block.num_channels() {
+            assert_eq!(block.channel(i).count(), 5);
+            assert_eq!(block.channel_mut(i).count(), 5);
         }
         for i in 0..block.num_frames() {
             assert_eq!(block.frame(i).count(), 2);
@@ -671,39 +566,61 @@ mod tests {
     }
 
     #[test]
-    fn test_pointer() {
-        unsafe {
-            let num_channels = 2;
-            let num_frames = 5;
-            let mut data = [vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_resize_channels() {
+        let mut block = Planar::<f32>::new(2, 10);
+        block.set_active_size(3, 10);
+    }
 
-            let mut ptr_vec: Vec<*mut f32> = data
-                .iter_mut()
-                .map(|inner_vec| inner_vec.as_mut_ptr())
-                .collect();
-            let ptr = ptr_vec.as_mut_ptr();
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_resize_frames() {
+        let mut block = Planar::<f32>::new(2, 10);
+        block.set_active_size(2, 11);
+    }
 
-            let mut adaptor =
-                StackedPtrAdapterMut::<_, 16>::from_ptr(ptr, num_channels, num_frames);
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_channel() {
+        let mut block = Planar::<f32>::new(2, 10);
+        block.set_active_size(1, 10);
+        let _ = block.channel(1);
+    }
 
-            let stacked = adaptor.stacked_view_mut();
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_frame() {
+        let mut block = Planar::<f32>::new(2, 10);
+        block.set_active_size(2, 5);
+        let _ = block.frame(5);
+    }
 
-            assert_eq!(
-                stacked.channel(0).copied().collect::<Vec<_>>(),
-                vec![0.0, 2.0, 4.0, 6.0, 8.0]
-            );
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_channel_mut() {
+        let mut block = Planar::<f32>::new(2, 10);
+        block.set_active_size(1, 10);
+        let _ = block.channel_mut(1);
+    }
 
-            assert_eq!(
-                stacked.channel(1).copied().collect::<Vec<_>>(),
-                vec![1.0, 3.0, 5.0, 7.0, 9.0]
-            );
-        }
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_frame_mut() {
+        let mut block = Planar::<f32>::new(2, 10);
+        block.set_active_size(2, 5);
+        let _ = block.frame_mut(5);
     }
 
     #[test]
     fn test_slice() {
-        let mut data = [[0.0; 4]; 3];
-        let mut block = StackedViewMut::from_slice_limited(&mut data, 2, 3);
+        let mut block = Planar::<f32>::new(3, 4);
+        block.set_active_size(2, 3);
 
         assert!(block.frame_slice(0).is_none());
 
@@ -717,8 +634,8 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
-        let mut data = [[0.0; 4]; 3];
-        let block = StackedViewMut::from_slice_limited(&mut data, 2, 3);
+        let mut block = Planar::<f32>::new(3, 4);
+        block.set_active_size(2, 3);
 
         block.channel_slice(2);
     }
@@ -727,8 +644,8 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
-        let mut data = [[0.0; 4]; 3];
-        let mut block = StackedViewMut::from_slice_limited(&mut data, 2, 3);
+        let mut block = Planar::<f32>::new(3, 4);
+        block.set_active_size(2, 3);
 
         block.channel_slice_mut(2);
     }
@@ -736,9 +653,9 @@ mod tests {
     #[test]
     fn test_raw_data() {
         let mut vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let mut block = StackedViewMut::from_slice(&mut vec);
+        let mut block = Planar::from_block(&PlanarViewMut::from_slice(&mut vec));
 
-        assert_eq!(block.layout(), crate::BlockLayout::Stacked);
+        assert_eq!(block.layout(), crate::BlockLayout::Planar);
 
         assert_eq!(block.raw_data(Some(0)), &[0.0, 2.0, 4.0, 6.0, 8.0]);
         assert_eq!(block.raw_data(Some(1)), &[1.0, 3.0, 5.0, 7.0, 9.0]);

--- a/src/planar/view.rs
+++ b/src/planar/view.rs
@@ -94,13 +94,13 @@ impl<'a, S: Sample, V: AsRef<[S]>> AudioBlockPlanarView<'a, S, V> {
 
 impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> {
     #[nonblocking]
-    fn num_frames(&self) -> usize {
-        self.num_frames
+    fn num_channels(&self) -> u16 {
+        self.num_channels
     }
 
     #[nonblocking]
-    fn num_channels(&self) -> u16 {
-        self.num_channels
+    fn num_frames(&self) -> usize {
+        self.num_frames
     }
 
     #[nonblocking]
@@ -111,6 +111,11 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
     #[nonblocking]
     fn num_frames_allocated(&self) -> usize {
         self.num_frames_allocated
+    }
+
+    #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Planar
     }
 
     #[nonblocking]
@@ -193,11 +198,6 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
             self.num_channels,
             self.num_frames,
         )
-    }
-
-    #[nonblocking]
-    fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Planar
     }
 
     #[nonblocking]

--- a/src/planar/view.rs
+++ b/src/planar/view.rs
@@ -201,10 +201,9 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
     }
 
     #[nonblocking]
-    fn raw_data(&self, planar_ch: Option<u16>) -> &[S] {
-        let ch = planar_ch.expect("For planar layout channel needs to be provided!");
+    fn raw_data_planar(&self, ch: u16) -> Option<&[S]> {
         assert!(ch < self.num_channels_allocated);
-        unsafe { self.data.get_unchecked(ch as usize).as_ref() }
+        Some(unsafe { self.data.get_unchecked(ch as usize).as_ref() })
     }
 }
 
@@ -513,7 +512,16 @@ mod tests {
 
         assert_eq!(block.layout(), crate::BlockLayout::Planar);
 
-        assert_eq!(block.raw_data(Some(0)), &[0.0, 2.0, 4.0, 6.0, 8.0]);
-        assert_eq!(block.raw_data(Some(1)), &[1.0, 3.0, 5.0, 7.0, 9.0]);
+        assert_eq!(block.raw_data_interleaved(), None);
+        assert_eq!(block.raw_data_sequential(), None);
+
+        assert_eq!(
+            block.raw_data_planar(0).unwrap(),
+            &[0.0, 2.0, 4.0, 6.0, 8.0]
+        );
+        assert_eq!(
+            block.raw_data_planar(1).unwrap(),
+            &[1.0, 3.0, 5.0, 7.0, 9.0]
+        );
     }
 }

--- a/src/planar/view.rs
+++ b/src/planar/view.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use crate::{AudioBlock, Sample};
 
-/// A read-only view of stacked / separate-channel audio data.
+/// A read-only view of planar / separate-channel audio data.
 ///
 /// * **Layout:** `[[ch0, ch0, ch0], [ch1, ch1, ch1]]`
 /// * **Interpretation:** Each channel has its own separate buffer or array.
@@ -18,12 +18,12 @@ use crate::{AudioBlock, Sample};
 ///
 /// let data = vec![[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]];
 ///
-/// let block = StackedView::from_slice(&data);
+/// let block = PlanarView::from_slice(&data);
 ///
 /// block.channel(0).for_each(|&v| assert_eq!(v, 0.0));
 /// block.channel(1).for_each(|&v| assert_eq!(v, 1.0));
 /// ```
-pub struct StackedView<'a, S: Sample, V: AsRef<[S]>> {
+pub struct PlanarView<'a, S: Sample, V: AsRef<[S]>> {
     data: &'a [V],
     num_channels: u16,
     num_frames: usize,
@@ -32,11 +32,11 @@ pub struct StackedView<'a, S: Sample, V: AsRef<[S]>> {
     _phantom: PhantomData<S>,
 }
 
-impl<'a, S: Sample, V: AsRef<[S]>> StackedView<'a, S, V> {
-    /// Creates a new [`StackedView`] from a slice of stacked audio data.
+impl<'a, S: Sample, V: AsRef<[S]>> PlanarView<'a, S, V> {
+    /// Creates a new [`PlanarView`] from a slice of planar audio data.
     ///
     /// # Parameters
-    /// * `data` - The slice containing stacked audio samples (one slice per channel)
+    /// * `data` - The slice containing planar audio samples (one slice per channel)
     ///
     /// # Panics
     /// Panics if the channel slices have different lengths.
@@ -50,13 +50,13 @@ impl<'a, S: Sample, V: AsRef<[S]>> StackedView<'a, S, V> {
         Self::from_slice_limited(data, data.len() as u16, num_frames_available)
     }
 
-    /// Creates a new [`StackedView`] from a slice with limited visibility.
+    /// Creates a new [`PlanarView`] from a slice with limited visibility.
     ///
     /// This function allows creating a view that exposes only a subset of the allocated channels
     /// and frames, which is useful for working with a logical section of a larger buffer.
     ///
     /// # Parameters
-    /// * `data` - The slice containing stacked audio samples (one slice per channel)
+    /// * `data` - The slice containing planar audio samples (one slice per channel)
     /// * `num_channels_visible` - Number of audio channels to expose in the view
     /// * `num_frames_visible` - Number of audio frames to expose in the view
     ///
@@ -92,7 +92,7 @@ impl<'a, S: Sample, V: AsRef<[S]>> StackedView<'a, S, V> {
     }
 }
 
-impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for StackedView<'_, S, V> {
+impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for PlanarView<'_, S, V> {
     #[nonblocking]
     fn num_frames(&self) -> usize {
         self.num_frames
@@ -188,23 +188,23 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for StackedView<'_, S, V> {
 
     #[nonblocking]
     fn view(&self) -> impl AudioBlock<S> {
-        StackedView::<S, V>::from_slice_limited(self.data, self.num_channels, self.num_frames)
+        PlanarView::<S, V>::from_slice_limited(self.data, self.num_channels, self.num_frames)
     }
 
     #[nonblocking]
     fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Stacked
+        crate::BlockLayout::Planar
     }
 
     #[nonblocking]
-    fn raw_data(&self, stacked_ch: Option<u16>) -> &[S] {
-        let ch = stacked_ch.expect("For stacked layout channel needs to be provided!");
+    fn raw_data(&self, planar_ch: Option<u16>) -> &[S] {
+        let ch = planar_ch.expect("For planar layout channel needs to be provided!");
         assert!(ch < self.num_channels_allocated);
         unsafe { self.data.get_unchecked(ch as usize).as_ref() }
     }
 }
 
-/// Adapter for creating stacked audio block views from raw pointers.
+/// Adapter for creating planar audio block views from raw pointers.
 ///
 /// This adapter provides a safe interface to work with audio data stored in external buffers,
 /// which is common when interfacing with audio APIs or hardware.
@@ -225,10 +225,10 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for StackedView<'_, S, V> {
 /// let num_frames = 5;
 ///
 /// // Create an adapter from raw pointers to audio channel data
-/// let adapter = unsafe { StackedPtrAdapter::<f32, 16>::from_ptr(data, num_channels, num_frames) };
+/// let adapter = unsafe { PlanarPtrAdapter::<f32, 16>::from_ptr(data, num_channels, num_frames) };
 ///
 /// // Get a safe view of the audio data
-/// let block = adapter.stacked_view();
+/// let block = adapter.planar_view();
 ///
 /// // Verify the data access works
 /// assert_eq!(block.sample(0, 2), 2.0);
@@ -241,13 +241,13 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for StackedView<'_, S, V> {
 /// - The pointers are valid and properly aligned
 /// - The memory they point to remains valid for the lifetime of the adapter
 /// - The channel count doesn't exceed the adapter's `MAX_CHANNELS` capacity
-pub struct StackedPtrAdapter<'a, S: Sample, const MAX_CHANNELS: usize> {
+pub struct PlanarPtrAdapter<'a, S: Sample, const MAX_CHANNELS: usize> {
     data: [MaybeUninit<&'a [S]>; MAX_CHANNELS],
     num_channels: u16,
 }
 
-impl<'a, S: Sample, const MAX_CHANNELS: usize> StackedPtrAdapter<'a, S, MAX_CHANNELS> {
-    /// Creates new StackedPtrAdapter from raw pointers.
+impl<'a, S: Sample, const MAX_CHANNELS: usize> PlanarPtrAdapter<'a, S, MAX_CHANNELS> {
+    /// Creates new PlanarPtrAdapter from raw pointers.
     ///
     /// # Safety
     ///
@@ -294,7 +294,7 @@ impl<'a, S: Sample, const MAX_CHANNELS: usize> StackedPtrAdapter<'a, S, MAX_CHAN
         }
     }
 
-    /// Creates a safe [`StackedView`] for accessing the audio data.
+    /// Creates a safe [`PlanarView`] for accessing the audio data.
     ///
     /// This provides a convenient way to interact with the audio data through
     /// the full [`AudioBlock`] interface, enabling operations like iterating
@@ -302,10 +302,10 @@ impl<'a, S: Sample, const MAX_CHANNELS: usize> StackedPtrAdapter<'a, S, MAX_CHAN
     ///
     /// # Returns
     ///
-    /// A [`StackedView`] that provides safe, immutable access to the audio data.
+    /// A [`PlanarView`] that provides safe, immutable access to the audio data.
     #[nonblocking]
-    pub fn stacked_view(&self) -> StackedView<'a, S, &[S]> {
-        StackedView::from_slice(self.data_slice())
+    pub fn planar_view(&self) -> PlanarView<'a, S, &[S]> {
+        PlanarView::from_slice(self.data_slice())
     }
 }
 
@@ -320,7 +320,7 @@ mod tests {
         let ch1 = &[0.0, 1.0, 2.0, 3.0, 4.0];
         let ch2 = &[5.0, 6.0, 7.0, 8.0, 9.0];
         let data = [ch1, ch2];
-        let block = StackedView::from_slice(&data);
+        let block = PlanarView::from_slice(&data);
 
         for ch in 0..block.num_channels() {
             for f in 0..block.num_frames() {
@@ -337,7 +337,7 @@ mod tests {
         let ch1 = vec![0.0, 2.0, 4.0, 6.0, 8.0];
         let ch2 = vec![1.0, 3.0, 5.0, 7.0, 9.0];
         let data = vec![ch1, ch2];
-        let block = StackedView::from_slice(&data);
+        let block = PlanarView::from_slice(&data);
 
         let channel = block.channel(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 2.0, 4.0, 6.0, 8.0]);
@@ -350,7 +350,7 @@ mod tests {
         let ch1 = vec![0.0, 2.0, 4.0, 6.0, 8.0];
         let ch2 = vec![1.0, 3.0, 5.0, 7.0, 9.0];
         let data = vec![ch1, ch2];
-        let block = StackedView::from_slice(&data);
+        let block = PlanarView::from_slice(&data);
 
         let mut channels_iter = block.channels();
         let channel = channels_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -366,7 +366,7 @@ mod tests {
         let ch1 = vec![0.0, 2.0, 4.0, 6.0, 8.0];
         let ch2 = vec![1.0, 3.0, 5.0, 7.0, 9.0];
         let data = vec![ch1.as_slice(), ch2.as_slice()];
-        let block = StackedView::from_slice(&data);
+        let block = PlanarView::from_slice(&data);
 
         let channel = block.frame(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 1.0]);
@@ -385,7 +385,7 @@ mod tests {
         let ch1 = vec![0.0, 2.0, 4.0, 6.0, 8.0];
         let ch2 = vec![1.0, 3.0, 5.0, 7.0, 9.0];
         let data = vec![ch1.as_slice(), ch2.as_slice()];
-        let block = StackedView::from_slice(&data);
+        let block = PlanarView::from_slice(&data);
 
         let mut frames_iter = block.frames();
         let channel = frames_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -404,7 +404,7 @@ mod tests {
     #[test]
     fn test_from_vec() {
         let vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let block = StackedView::from_slice(&vec);
+        let block = PlanarView::from_slice(&vec);
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 5);
         assert_eq!(
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn test_view() {
         let vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let block = StackedView::from_slice(&vec);
+        let block = PlanarView::from_slice(&vec);
         let view = block.view();
         assert_eq!(
             view.channel(0).copied().collect::<Vec<_>>(),
@@ -441,7 +441,7 @@ mod tests {
     fn test_limited() {
         let data = vec![vec![0.0; 4]; 3];
 
-        let block = StackedView::from_slice_limited(&data, 2, 3);
+        let block = PlanarView::from_slice_limited(&data, 2, 3);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 3);
@@ -467,16 +467,16 @@ mod tests {
                 vec.iter_mut().map(|inner_vec| inner_vec.as_ptr()).collect();
             let ptr = ptr_vec.as_ptr();
 
-            let adapter = StackedPtrAdapter::<_, 16>::from_ptr(ptr, num_channels, num_frames);
-            let stacked = adapter.stacked_view();
+            let adapter = PlanarPtrAdapter::<_, 16>::from_ptr(ptr, num_channels, num_frames);
+            let planar = adapter.planar_view();
 
             assert_eq!(
-                stacked.channel(0).copied().collect::<Vec<_>>(),
+                planar.channel(0).copied().collect::<Vec<_>>(),
                 vec![0.0, 2.0, 4.0, 6.0, 8.0]
             );
 
             assert_eq!(
-                stacked.channel(1).copied().collect::<Vec<_>>(),
+                planar.channel(1).copied().collect::<Vec<_>>(),
                 vec![1.0, 3.0, 5.0, 7.0, 9.0]
             );
         }
@@ -485,7 +485,7 @@ mod tests {
     #[test]
     fn test_slice() {
         let data = [[1.0; 4], [2.0; 4], [0.0; 4]];
-        let block = StackedView::from_slice_limited(&data, 2, 3);
+        let block = PlanarView::from_slice_limited(&data, 2, 3);
 
         assert!(block.frame_slice(0).is_none());
 
@@ -498,7 +498,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let data = [[1.0; 4], [2.0; 4], [0.0; 4]];
-        let block = StackedView::from_slice_limited(&data, 2, 3);
+        let block = PlanarView::from_slice_limited(&data, 2, 3);
 
         block.channel_slice(2);
     }
@@ -506,9 +506,9 @@ mod tests {
     #[test]
     fn test_raw_data() {
         let vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let block = StackedView::from_slice(&vec);
+        let block = PlanarView::from_slice(&vec);
 
-        assert_eq!(block.layout(), crate::BlockLayout::Stacked);
+        assert_eq!(block.layout(), crate::BlockLayout::Planar);
 
         assert_eq!(block.raw_data(Some(0)), &[0.0, 2.0, 4.0, 6.0, 8.0]);
         assert_eq!(block.raw_data(Some(1)), &[1.0, 3.0, 5.0, 7.0, 9.0]);

--- a/src/planar/view_mut.rs
+++ b/src/planar/view_mut.rs
@@ -116,6 +116,11 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
     }
 
     #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Planar
+    }
+
+    #[nonblocking]
     fn sample(&self, channel: u16, frame: usize) -> S {
         assert!(channel < self.num_channels);
         assert!(frame < self.num_frames);
@@ -195,11 +200,6 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
     #[nonblocking]
     fn view(&self) -> impl AudioBlock<S> {
         AudioBlockPlanarView::from_slice_limited(self.data, self.num_channels, self.num_frames)
-    }
-
-    #[nonblocking]
-    fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Planar
     }
 
     #[nonblocking]

--- a/src/planar/view_mut.rs
+++ b/src/planar/view_mut.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use crate::{AudioBlock, AudioBlockMut, Sample};
 
-use super::PlanarView;
+use super::AudioBlockPlanarView;
 
 /// A mutable view of planar / separate-channel audio data.
 ///
@@ -20,12 +20,12 @@ use super::PlanarView;
 ///
 /// let mut data = vec![[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]];
 ///
-/// let block = PlanarViewMut::from_slice(&mut data);
+/// let block = AudioBlockPlanarViewMut::from_slice(&mut data);
 ///
 /// block.channel(0).for_each(|&v| assert_eq!(v, 0.0));
 /// block.channel(1).for_each(|&v| assert_eq!(v, 1.0));
 /// ```
-pub struct PlanarViewMut<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> {
+pub struct AudioBlockPlanarViewMut<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> {
     data: &'a mut [V],
     num_channels: u16,
     num_frames: usize,
@@ -34,8 +34,8 @@ pub struct PlanarViewMut<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> {
     _phantom: PhantomData<S>,
 }
 
-impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> PlanarViewMut<'a, S, V> {
-    /// Creates a new [`PlanarViewMut`] from a mutable slice of planar audio data.
+impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockPlanarViewMut<'a, S, V> {
+    /// Creates a new audio block from a mutable slice of planar audio data.
     ///
     /// # Parameters
     /// * `data` - The mutable slice containing planar audio samples (one slice per channel)
@@ -52,7 +52,7 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> PlanarViewMut<'a, S, V> {
         Self::from_slice_limited(data, data.len() as u16, num_frames_available)
     }
 
-    /// Creates a new [`PlanarViewMut`] from a mutable slice with limited visibility.
+    /// Creates a new audio block from a mutable slice with limited visibility.
     ///
     /// This function allows creating a view that exposes only a subset of the allocated channels
     /// and frames, which is useful for working with a logical section of a larger buffer.
@@ -94,7 +94,7 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> PlanarViewMut<'a, S, V> {
     }
 }
 
-impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for PlanarViewMut<'_, S, V> {
+impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarViewMut<'_, S, V> {
     #[nonblocking]
     fn num_channels(&self) -> u16 {
         self.num_channels
@@ -194,7 +194,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for PlanarViewMut<'_, 
 
     #[nonblocking]
     fn view(&self) -> impl AudioBlock<S> {
-        PlanarView::from_slice_limited(self.data, self.num_channels, self.num_frames)
+        AudioBlockPlanarView::from_slice_limited(self.data, self.num_channels, self.num_frames)
     }
 
     #[nonblocking]
@@ -210,7 +210,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for PlanarViewMut<'_, 
     }
 }
 
-impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for PlanarViewMut<'_, S, V> {
+impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlanarViewMut<'_, S, V> {
     #[nonblocking]
     fn set_active_num_channels(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
@@ -298,7 +298,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for PlanarViewMut<'
 
     #[nonblocking]
     fn view_mut(&mut self) -> impl AudioBlockMut<S> {
-        PlanarViewMut::from_slice_limited(self.data, self.num_channels, self.num_frames)
+        AudioBlockPlanarViewMut::from_slice_limited(self.data, self.num_channels, self.num_frames)
     }
 
     #[nonblocking]
@@ -354,7 +354,7 @@ pub struct PlanarPtrAdapterMut<'a, S: Sample, const MAX_CHANNELS: usize> {
 }
 
 impl<'a, S: Sample, const MAX_CHANNELS: usize> PlanarPtrAdapterMut<'a, S, MAX_CHANNELS> {
-    /// Creates new [`PlanarPtrAdapterMut`] from raw pointers.
+    /// Creates new pointer adapter to create an audio block from raw pointers.
     ///
     /// # Safety
     ///
@@ -401,7 +401,7 @@ impl<'a, S: Sample, const MAX_CHANNELS: usize> PlanarPtrAdapterMut<'a, S, MAX_CH
         }
     }
 
-    /// Creates a safe [`PlanarViewMut`] for accessing the audio data.
+    /// Creates a safe [`AudioBlockPlanarViewMut`] for accessing the audio data.
     ///
     /// This provides a convenient way to interact with the audio data through
     /// the full [`AudioBlockMut`] interface, enabling operations like iterating
@@ -409,10 +409,10 @@ impl<'a, S: Sample, const MAX_CHANNELS: usize> PlanarPtrAdapterMut<'a, S, MAX_CH
     ///
     /// # Returns
     ///
-    /// A [`PlanarViewMut`] that provides safe, mutable access to the audio data.
+    /// An [`AudioBlockPlanarViewMut`] that provides safe, mutable access to the audio data.
     #[nonblocking]
-    pub fn planar_view_mut(&mut self) -> PlanarViewMut<'a, S, &mut [S]> {
-        PlanarViewMut::from_slice(self.data_slice_mut())
+    pub fn planar_view_mut(&mut self) -> AudioBlockPlanarViewMut<'a, S, &mut [S]> {
+        AudioBlockPlanarViewMut::from_slice(self.data_slice_mut())
     }
 }
 
@@ -428,7 +428,7 @@ mod tests {
         let mut ch1 = vec![0.0; 5];
         let mut ch2 = vec![0.0; 5];
         let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice()];
-        let mut block = PlanarViewMut::from_slice(&mut data);
+        let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
 
         let num_frames = block.num_frames();
         for ch in 0..block.num_channels() {
@@ -452,7 +452,7 @@ mod tests {
         let mut ch1 = vec![0.0; 5];
         let mut ch2 = vec![0.0; 5];
         let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice()];
-        let mut block = PlanarViewMut::from_slice(&mut data);
+        let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
 
         let channel = block.channel(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 0.0, 0.0, 0.0, 0.0]);
@@ -479,7 +479,7 @@ mod tests {
         let mut ch1 = vec![0.0; 5];
         let mut ch2 = vec![0.0; 5];
         let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice()];
-        let mut block = PlanarViewMut::from_slice(&mut data);
+        let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
 
         let mut channels_iter = block.channels();
         let channel = channels_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -517,7 +517,7 @@ mod tests {
         let mut ch1 = vec![0.0; 5];
         let mut ch2 = vec![0.0; 5];
         let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice()];
-        let mut block = PlanarViewMut::from_slice(&mut data);
+        let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
 
         for i in 0..block.num_frames() {
             let frame = block.frame(i).copied().collect::<Vec<_>>();
@@ -550,7 +550,7 @@ mod tests {
         let mut ch2 = vec![0.0; 10];
         let mut ch3 = vec![0.0; 10];
         let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice(), ch3.as_mut_slice()];
-        let mut block = PlanarViewMut::from_slice(&mut data);
+        let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
         block.set_active_size(2, 5);
 
         let num_frames = block.num_frames;
@@ -591,7 +591,7 @@ mod tests {
     #[test]
     fn test_from_vec() {
         let mut vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let block = PlanarViewMut::from_slice(&mut vec);
+        let block = AudioBlockPlanarViewMut::from_slice(&mut vec);
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 5);
         assert_eq!(
@@ -612,7 +612,7 @@ mod tests {
     #[test]
     fn test_view() {
         let mut vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let block = PlanarViewMut::from_slice(&mut vec);
+        let block = AudioBlockPlanarViewMut::from_slice(&mut vec);
         let view = block.view();
         assert_eq!(
             view.channel(0).copied().collect::<Vec<_>>(),
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn test_view_mut() {
         let mut data = vec![vec![0.0; 5]; 2];
-        let mut block = PlanarViewMut::from_slice(&mut data);
+        let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
 
         {
             let mut view = block.view_mut();
@@ -653,7 +653,7 @@ mod tests {
     fn test_limited() {
         let mut data = vec![vec![0.0; 4]; 3];
 
-        let mut block = PlanarViewMut::from_slice_limited(&mut data, 2, 3);
+        let mut block = AudioBlockPlanarViewMut::from_slice_limited(&mut data, 2, 3);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 3);
@@ -702,7 +702,7 @@ mod tests {
     #[test]
     fn test_slice() {
         let mut data = [[0.0; 4]; 3];
-        let mut block = PlanarViewMut::from_slice_limited(&mut data, 2, 3);
+        let mut block = AudioBlockPlanarViewMut::from_slice_limited(&mut data, 2, 3);
 
         assert!(block.frame_slice(0).is_none());
 
@@ -717,7 +717,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let mut data = [[0.0; 4]; 3];
-        let block = PlanarViewMut::from_slice_limited(&mut data, 2, 3);
+        let block = AudioBlockPlanarViewMut::from_slice_limited(&mut data, 2, 3);
 
         block.channel_slice(2);
     }
@@ -727,7 +727,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
         let mut data = [[0.0; 4]; 3];
-        let mut block = PlanarViewMut::from_slice_limited(&mut data, 2, 3);
+        let mut block = AudioBlockPlanarViewMut::from_slice_limited(&mut data, 2, 3);
 
         block.channel_slice_mut(2);
     }
@@ -735,7 +735,7 @@ mod tests {
     #[test]
     fn test_raw_data() {
         let mut vec = vec![vec![0.0, 2.0, 4.0, 6.0, 8.0], vec![1.0, 3.0, 5.0, 7.0, 9.0]];
-        let mut block = PlanarViewMut::from_slice(&mut vec);
+        let mut block = AudioBlockPlanarViewMut::from_slice(&mut vec);
 
         assert_eq!(block.layout(), crate::BlockLayout::Planar);
 

--- a/src/sequential/mod.rs
+++ b/src/sequential/mod.rs
@@ -4,6 +4,6 @@ mod view;
 mod view_mut;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use owned::Sequential;
-pub use view::SequentialView;
-pub use view_mut::SequentialViewMut;
+pub use owned::AudioBlockSequential;
+pub use view::AudioBlockSequentialView;
+pub use view_mut::AudioBlockSequentialViewMut;

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -121,6 +121,11 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Sequential
+    }
+
+    #[nonblocking]
     fn sample(&self, channel: u16, frame: usize) -> S {
         assert!(channel < self.num_channels);
         assert!(frame < self.num_frames);
@@ -210,11 +215,6 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
             self.num_channels_allocated,
             self.num_frames_allocated,
         )
-    }
-
-    #[nonblocking]
-    fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Sequential
     }
 
     #[nonblocking]

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -8,17 +8,17 @@ use std::{boxed::Box, vec, vec::Vec};
 #[cfg(all(feature = "std", feature = "alloc"))]
 use std::{boxed::Box, vec, vec::Vec};
 
-use super::{view::SequentialView, view_mut::SequentialViewMut};
+use super::{view::AudioBlockSequentialView, view_mut::AudioBlockSequentialViewMut};
 use crate::{
     AudioBlock, AudioBlockMut, Sample,
     iter::{StridedSampleIter, StridedSampleIterMut},
 };
 
-/// A sequential / planar audio block that owns its data.
+/// A sequential audio block that owns its data.
 ///
 /// * **Layout:** `[ch0, ch0, ch0, ch1, ch1, ch1]`
 /// * **Interpretation:** All samples from `ch0` are stored first, followed by all from `ch1`, etc.
-/// * **Terminology:** Described as “planar” or “channels first” in the sense that all data for one channel appears before any data for the next.
+/// * **Terminology:** Described as “channels first” in the sense that all data for one channel appears before any data for the next.
 /// * **Usage:** Used in DSP pipelines where per-channel processing is easier and more efficient.
 ///
 /// # Example
@@ -26,15 +26,15 @@ use crate::{
 /// ```
 /// use audio_blocks::*;
 ///
-/// let block = Sequential::new(2, 3);
-/// let mut block = Sequential::from_block(&block);
+/// let block = AudioBlockSequential::new(2, 3);
+/// let mut block = AudioBlockSequential::from_block(&block);
 ///
 /// block.channel_mut(0).for_each(|v| *v = 0.0);
 /// block.channel_mut(1).for_each(|v| *v = 1.0);
 ///
 /// assert_eq!(block.raw_data(None), &[0.0, 0.0, 0.0, 1.0, 1.0, 1.0]);
 /// ```
-pub struct Sequential<S: Sample> {
+pub struct AudioBlockSequential<S: Sample> {
     data: Box<[S]>,
     num_channels: u16,
     num_frames: usize,
@@ -42,12 +42,11 @@ pub struct Sequential<S: Sample> {
     num_frames_allocated: usize,
 }
 
-impl<S: Sample> Sequential<S> {
-    /// Creates a new [`Sequential`] audio block with the specified dimensions.
+impl<S: Sample> AudioBlockSequential<S> {
+    /// Creates a new audio block with the specified dimensions.
     ///
-    /// Allocates memory for a new sequential audio block with exactly the specified
-    /// number of channels and frames. The block is initialized with the default value
-    /// for the sample type.
+    /// Allocates memory with exactly the specified number of channels and
+    /// frames. The block is initialized with zeros.
     ///
     /// Do not use in real-time processes!
     ///
@@ -73,7 +72,7 @@ impl<S: Sample> Sequential<S> {
         }
     }
 
-    /// Creates a new [`Sequential`] audio block by copying data from another [`AudioBlock`].
+    /// Creates a new audio block by copying data from another [`AudioBlock`].
     ///
     /// Converts any [`AudioBlock`] implementation to a sequential format by iterating
     /// through each channel of the source block and copying its samples. The new block
@@ -100,7 +99,7 @@ impl<S: Sample> Sequential<S> {
     }
 }
 
-impl<S: Sample> AudioBlock<S> for Sequential<S> {
+impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
     #[nonblocking]
     fn num_channels(&self) -> u16 {
         self.num_channels
@@ -204,7 +203,7 @@ impl<S: Sample> AudioBlock<S> for Sequential<S> {
 
     #[nonblocking]
     fn view(&self) -> impl AudioBlock<S> {
-        SequentialView::from_slice_limited(
+        AudioBlockSequentialView::from_slice_limited(
             &self.data,
             self.num_channels,
             self.num_frames,
@@ -224,7 +223,7 @@ impl<S: Sample> AudioBlock<S> for Sequential<S> {
     }
 }
 
-impl<S: Sample> AudioBlockMut<S> for Sequential<S> {
+impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     #[nonblocking]
     fn set_active_num_channels(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
@@ -318,7 +317,7 @@ impl<S: Sample> AudioBlockMut<S> for Sequential<S> {
 
     #[nonblocking]
     fn view_mut(&mut self) -> impl AudioBlockMut<S> {
-        SequentialViewMut::from_slice_limited(
+        AudioBlockSequentialViewMut::from_slice_limited(
             &mut self.data,
             self.num_channels,
             self.num_frames,
@@ -338,11 +337,11 @@ mod tests {
     use rtsan_standalone::no_sanitize_realtime;
 
     use super::*;
-    use crate::interleaved::InterleavedView;
+    use crate::interleaved::AudioBlockInterleavedView;
 
     #[test]
     fn test_samples() {
-        let mut block = Sequential::<f32>::new(2, 5);
+        let mut block = AudioBlockSequential::<f32>::new(2, 5);
 
         let num_frames = block.num_frames();
         for ch in 0..block.num_channels() {
@@ -365,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_channel() {
-        let mut block = Sequential::<f32>::new(2, 5);
+        let mut block = AudioBlockSequential::<f32>::new(2, 5);
 
         let channel = block.channel(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 0.0, 0.0, 0.0, 0.0]);
@@ -389,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_channels() {
-        let mut block = Sequential::<f32>::new(2, 5);
+        let mut block = AudioBlockSequential::<f32>::new(2, 5);
 
         let mut channels_iter = block.channels();
         let channel = channels_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -424,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_frame() {
-        let mut block = Sequential::<f32>::new(2, 5);
+        let mut block = AudioBlockSequential::<f32>::new(2, 5);
 
         for i in 0..block.num_frames() {
             let frame = block.frame(i).copied().collect::<Vec<_>>();
@@ -453,7 +452,7 @@ mod tests {
 
     #[test]
     fn test_frames() {
-        let mut block = Sequential::<f32>::new(3, 6);
+        let mut block = AudioBlockSequential::<f32>::new(3, 6);
         block.set_active_size(2, 5);
 
         let num_frames = block.num_frames;
@@ -493,11 +492,12 @@ mod tests {
 
     #[test]
     fn test_from_slice() {
-        let block = Sequential::<f32>::from_block(&InterleavedView::from_slice(
-            &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-            2,
-            5,
-        ));
+        let block =
+            AudioBlockSequential::<f32>::from_block(&AudioBlockInterleavedView::from_slice(
+                &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                2,
+                5,
+            ));
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated(), 2);
         assert_eq!(block.num_frames(), 5);
@@ -519,11 +519,12 @@ mod tests {
 
     #[test]
     fn test_view() {
-        let block = Sequential::<f32>::from_block(&InterleavedView::from_slice(
-            &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-            2,
-            5,
-        ));
+        let block =
+            AudioBlockSequential::<f32>::from_block(&AudioBlockInterleavedView::from_slice(
+                &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+                2,
+                5,
+            ));
         let view = block.view();
         assert_eq!(
             view.channel(0).copied().collect::<Vec<_>>(),
@@ -537,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_view_mut() {
-        let mut block = Sequential::<f32>::new(2, 5);
+        let mut block = AudioBlockSequential::<f32>::new(2, 5);
         {
             let mut view = block.view_mut();
             view.channel_mut(0)
@@ -560,7 +561,7 @@ mod tests {
 
     #[test]
     fn test_slice() {
-        let mut block = Sequential::<f32>::new(3, 6);
+        let mut block = AudioBlockSequential::<f32>::new(3, 6);
         block.set_active_size(2, 5);
         assert!(block.frame_slice(0).is_none());
 
@@ -574,7 +575,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
-        let mut block = Sequential::<f32>::new(3, 6);
+        let mut block = AudioBlockSequential::<f32>::new(3, 6);
         block.set_active_size(2, 5);
         block.channel_slice(2);
     }
@@ -583,14 +584,14 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
-        let mut block = Sequential::<f32>::new(3, 6);
+        let mut block = AudioBlockSequential::<f32>::new(3, 6);
         block.set_active_size(2, 5);
         block.channel_slice_mut(2);
     }
 
     #[test]
     fn test_resize() {
-        let mut block = Sequential::<f32>::new(3, 10);
+        let mut block = AudioBlockSequential::<f32>::new(3, 10);
         assert_eq!(block.num_channels(), 3);
         assert_eq!(block.num_frames(), 10);
         assert_eq!(block.num_channels_allocated(), 3);
@@ -627,7 +628,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_resize_channels() {
-        let mut block = Sequential::<f32>::new(2, 10);
+        let mut block = AudioBlockSequential::<f32>::new(2, 10);
         block.set_active_size(3, 10);
     }
 
@@ -635,7 +636,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_resize_frames() {
-        let mut block = Sequential::<f32>::new(2, 10);
+        let mut block = AudioBlockSequential::<f32>::new(2, 10);
         block.set_active_size(2, 11);
     }
 
@@ -643,7 +644,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_channel() {
-        let mut block = Sequential::<f32>::new(2, 10);
+        let mut block = AudioBlockSequential::<f32>::new(2, 10);
         block.set_active_size(1, 10);
         let _ = block.channel(1);
     }
@@ -652,7 +653,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_frame() {
-        let mut block = Sequential::<f32>::new(2, 10);
+        let mut block = AudioBlockSequential::<f32>::new(2, 10);
         block.set_active_size(2, 5);
         let _ = block.frame(5);
     }
@@ -661,7 +662,7 @@ mod tests {
     #[should_panic]
     #[no_sanitize_realtime]
     fn test_wrong_channel_mut() {
-        let mut block = Sequential::<f32>::new(2, 10);
+        let mut block = AudioBlockSequential::<f32>::new(2, 10);
         block.set_active_size(1, 10);
         let _ = block.channel_mut(1);
     }

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -261,8 +261,8 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
     }
 
     #[nonblocking]
-    fn raw_data(&self, _: Option<u16>) -> &[S] {
-        self.data
+    fn raw_data_sequential(&self) -> Option<&[S]> {
+        Some(self.data)
     }
 }
 
@@ -476,8 +476,11 @@ mod tests {
 
         assert_eq!(block.layout(), crate::BlockLayout::Sequential);
 
+        assert_eq!(block.raw_data_interleaved(), None);
+        assert_eq!(block.raw_data_planar(0), None);
+
         assert_eq!(
-            block.raw_data(None),
+            block.raw_data_sequential().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
     }

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -164,6 +164,11 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
     }
 
     #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Sequential
+    }
+
+    #[nonblocking]
     fn sample(&self, channel: u16, frame: usize) -> S {
         assert!(channel < self.num_channels);
         assert!(frame < self.num_frames);
@@ -253,11 +258,6 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
             self.num_channels_allocated,
             self.num_frames_allocated,
         )
-    }
-
-    #[nonblocking]
-    fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Sequential
     }
 
     #[nonblocking]

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -269,8 +269,8 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn raw_data(&self, _: Option<u16>) -> &[S] {
-        self.data
+    fn raw_data_sequential(&self) -> Option<&[S]> {
+        Some(self.data)
     }
 }
 
@@ -378,8 +378,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn raw_data_mut(&mut self, _: Option<u16>) -> &mut [S] {
-        self.data
+    fn raw_data_sequential_mut(&mut self) -> Option<&mut [S]> {
+        Some(self.data)
     }
 }
 
@@ -408,7 +408,7 @@ mod tests {
         }
 
         assert_eq!(
-            block.raw_data(None),
+            block.raw_data_sequential().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
     }
@@ -716,13 +716,18 @@ mod tests {
 
         assert_eq!(block.layout(), crate::BlockLayout::Sequential);
 
+        assert_eq!(block.raw_data_interleaved(), None);
+        assert_eq!(block.raw_data_interleaved_mut(), None);
+        assert_eq!(block.raw_data_planar(0), None);
+        assert_eq!(block.raw_data_planar_mut(0), None);
+
         assert_eq!(
-            block.raw_data(None),
+            block.raw_data_sequential().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
 
         assert_eq!(
-            block.raw_data_mut(None),
+            block.raw_data_sequential_mut().unwrap(),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
         );
     }

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -152,13 +152,13 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
 
 impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     #[nonblocking]
-    fn num_frames(&self) -> usize {
-        self.num_frames
+    fn num_channels(&self) -> u16 {
+        self.num_channels
     }
 
     #[nonblocking]
-    fn num_channels(&self) -> u16 {
-        self.num_channels
+    fn num_frames(&self) -> usize {
+        self.num_frames
     }
 
     #[nonblocking]
@@ -169,6 +169,11 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     #[nonblocking]
     fn num_frames_allocated(&self) -> usize {
         self.num_frames_allocated
+    }
+
+    #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Sequential
     }
 
     #[nonblocking]
@@ -261,11 +266,6 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
             self.num_channels_allocated,
             self.num_frames_allocated,
         )
-    }
-
-    #[nonblocking]
-    fn layout(&self) -> crate::BlockLayout {
-        crate::BlockLayout::Sequential
     }
 
     #[nonblocking]

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -2,17 +2,17 @@ use rtsan_standalone::nonblocking;
 
 use core::{marker::PhantomData, ptr::NonNull};
 
-use super::view::SequentialView;
+use super::view::AudioBlockSequentialView;
 use crate::{
     AudioBlock, AudioBlockMut, Sample,
     iter::{StridedSampleIter, StridedSampleIterMut},
 };
 
-///  A mutable view of sequential / planar audio data.
+///  A mutable view of sequential audio data.
 ///
 /// * **Layout:** `[ch0, ch0, ch0, ch1, ch1, ch1]`
 /// * **Interpretation:** All samples from `ch0` are stored first, followed by all from `ch1`, etc.
-/// * **Terminology:** Described as “planar” or “channels first” in the sense that all data for one channel appears before any data for the next.
+/// * **Terminology:** Described as “channels first” in the sense that all data for one channel appears before any data for the next.
 /// * **Usage:** Used in DSP pipelines where per-channel processing is easier and more efficient.
 ///
 /// # Example
@@ -22,12 +22,12 @@ use crate::{
 ///
 /// let mut data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
 ///
-/// let block = SequentialViewMut::from_slice(&mut data, 2, 3);
+/// let block = AudioBlockSequentialViewMut::from_slice(&mut data, 2, 3);
 ///
 /// block.channel(0).for_each(|&v| assert_eq!(v, 0.0));
 /// block.channel(1).for_each(|&v| assert_eq!(v, 1.0));
 /// ```
-pub struct SequentialViewMut<'a, S: Sample> {
+pub struct AudioBlockSequentialViewMut<'a, S: Sample> {
     data: &'a mut [S],
     num_channels: u16,
     num_frames: usize,
@@ -35,8 +35,8 @@ pub struct SequentialViewMut<'a, S: Sample> {
     num_frames_allocated: usize,
 }
 
-impl<'a, S: Sample> SequentialViewMut<'a, S> {
-    /// Creates a new [`SequentialViewMut`] from a mutable slice of sequential audio data.
+impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
+    /// Creates a new audio block from a mutable slice of sequential audio data.
     ///
     /// # Parameters
     /// * `data` - The mutable slice containing sequential audio samples
@@ -57,7 +57,7 @@ impl<'a, S: Sample> SequentialViewMut<'a, S> {
         }
     }
 
-    /// Creates a new [`SequentialViewMut`] from a mutable slice with limited visibility.
+    /// Creates a new audio block from a mutable slice with limited visibility.
     ///
     /// This function allows creating a view that exposes only a subset of the allocated channels
     /// and frames, which is useful for working with a logical section of a larger buffer.
@@ -96,7 +96,7 @@ impl<'a, S: Sample> SequentialViewMut<'a, S> {
         }
     }
 
-    /// Creates a new [`SequentialViewMut`] from a pointer.
+    /// Creates a new audio block from a pointer.
     ///
     /// # Safety
     ///
@@ -117,7 +117,7 @@ impl<'a, S: Sample> SequentialViewMut<'a, S> {
         }
     }
 
-    /// Creates a new [`SequentialViewMut`] from a pointer with a limited amount of channels and/or frames.
+    /// Creates a new audio block from a pointer with a limited amount of channels and/or frames.
     ///
     /// # Safety
     ///
@@ -150,7 +150,7 @@ impl<'a, S: Sample> SequentialViewMut<'a, S> {
     }
 }
 
-impl<S: Sample> AudioBlock<S> for SequentialViewMut<'_, S> {
+impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     #[nonblocking]
     fn num_frames(&self) -> usize {
         self.num_frames
@@ -254,7 +254,7 @@ impl<S: Sample> AudioBlock<S> for SequentialViewMut<'_, S> {
 
     #[nonblocking]
     fn view(&self) -> impl AudioBlock<S> {
-        SequentialView::from_slice_limited(
+        AudioBlockSequentialView::from_slice_limited(
             self.data,
             self.num_channels,
             self.num_frames,
@@ -274,7 +274,7 @@ impl<S: Sample> AudioBlock<S> for SequentialViewMut<'_, S> {
     }
 }
 
-impl<S: Sample> AudioBlockMut<S> for SequentialViewMut<'_, S> {
+impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     #[nonblocking]
     fn set_active_num_channels(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
@@ -368,7 +368,7 @@ impl<S: Sample> AudioBlockMut<S> for SequentialViewMut<'_, S> {
 
     #[nonblocking]
     fn view_mut(&mut self) -> impl AudioBlockMut<S> {
-        SequentialViewMut::from_slice_limited(
+        AudioBlockSequentialViewMut::from_slice_limited(
             self.data,
             self.num_channels,
             self.num_frames,
@@ -392,7 +392,7 @@ mod tests {
     #[test]
     fn test_samples() {
         let mut data = vec![0.0; 10];
-        let mut block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
 
         let num_frames = block.num_frames();
         for ch in 0..block.num_channels() {
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     fn test_channel() {
         let mut data = vec![0.0; 10];
-        let mut block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
 
         let channel = block.channel(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 0.0, 0.0, 0.0, 0.0]);
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn test_channels() {
         let mut data = vec![0.0; 10];
-        let mut block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
 
         let mut channels_iter = block.channels();
         let channel = channels_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn test_frame() {
         let mut data = vec![0.0; 12];
-        let mut block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
         block.set_active_size(2, 5);
 
         for i in 0..block.num_frames() {
@@ -508,7 +508,7 @@ mod tests {
     #[test]
     fn test_frames() {
         let mut data = vec![0.0; 12];
-        let mut block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
         block.set_active_size(2, 5);
 
         let num_frames = block.num_frames;
@@ -549,7 +549,7 @@ mod tests {
     #[test]
     fn test_from_slice() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated, 2);
         assert_eq!(block.num_frames(), 5);
@@ -572,7 +572,7 @@ mod tests {
     #[test]
     fn test_view() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
         let view = block.view();
         assert_eq!(
             view.channel(0).copied().collect::<Vec<_>>(),
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn test_view_mut() {
         let mut data = vec![0.0; 10];
-        let mut block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
 
         {
             let mut view = block.view_mut();
@@ -613,7 +613,7 @@ mod tests {
     fn test_limited() {
         let mut data = [1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 5.0, 6.0, 0.0, 0.0, 0.0, 0.0];
 
-        let mut block = SequentialViewMut::from_slice_limited(&mut data, 2, 3, 3, 4);
+        let mut block = AudioBlockSequentialViewMut::from_slice_limited(&mut data, 2, 3, 3, 4);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 3);
@@ -633,7 +633,8 @@ mod tests {
     #[test]
     fn test_from_raw() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = unsafe { SequentialViewMut::<f32>::from_ptr(data.as_mut_ptr(), 2, 5) };
+        let block =
+            unsafe { AudioBlockSequentialViewMut::<f32>::from_ptr(data.as_mut_ptr(), 2, 5) };
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated, 2);
         assert_eq!(block.num_frames(), 5);
@@ -658,7 +659,7 @@ mod tests {
         let mut data = [1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 5.0, 6.0, 0.0, 0.0, 0.0, 0.0];
 
         let mut block =
-            unsafe { SequentialViewMut::from_ptr_limited(data.as_mut_ptr(), 2, 3, 3, 4) };
+            unsafe { AudioBlockSequentialViewMut::from_ptr_limited(data.as_mut_ptr(), 2, 3, 3, 4) };
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 3);
@@ -678,7 +679,7 @@ mod tests {
     #[test]
     fn test_slice() {
         let mut data = [0.0; 3 * 4];
-        let mut block = SequentialViewMut::from_slice_limited(&mut data, 2, 3, 3, 4);
+        let mut block = AudioBlockSequentialViewMut::from_slice_limited(&mut data, 2, 3, 3, 4);
 
         assert!(block.frame_slice(0).is_none());
 
@@ -693,7 +694,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let mut data = [0.0; 3 * 4];
-        let block = SequentialViewMut::from_slice_limited(&mut data, 2, 3, 3, 4);
+        let block = AudioBlockSequentialViewMut::from_slice_limited(&mut data, 2, 3, 3, 4);
 
         block.channel_slice(2);
     }
@@ -703,7 +704,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
         let mut data = [0.0; 3 * 4];
-        let mut block = SequentialViewMut::from_slice_limited(&mut data, 2, 3, 3, 4);
+        let mut block = AudioBlockSequentialViewMut::from_slice_limited(&mut data, 2, 3, 3, 4);
 
         block.channel_slice_mut(2);
     }
@@ -711,7 +712,7 @@ mod tests {
     #[test]
     fn test_raw_data() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let mut block = SequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
 
         assert_eq!(block.layout(), crate::BlockLayout::Sequential);
 


### PR DESCRIPTION
# Breaking Changes

- Everything that was called `Stacked` before is now called `Planar`
- All Block structs now start with `AudioBlock` (`Interleaved` -> `AudioBlockInterleaved`, `SequentialViewMut` -> `AudioBlockSequentialViewMut`, etc.)
- `raw_data` and `raw_data_mut` got changed to be dependent on data layout:

```rs
fn raw_data_interleaved(&self) -> Option<&[S]>;
fn raw_data_sequential(&self) -> Option<&[S>];
fn raw_data_planar(&self, ch: u16) -> Option<&[S]>;
```

and the according mutable versions.