### PR TITLE
0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +64,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -116,10 +135,11 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -128,6 +148,7 @@ dependencies = [
  "itertools",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -139,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
  "cast",
  "itertools",
@@ -199,6 +220,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "getrandom"
@@ -359,6 +386,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "plotters"
@@ -558,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +728,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +751,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "audio-blocks"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "num",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,6 @@ name = "audio-blocks"
 version = "0.6.0"
 dependencies = [
  "criterion",
- "num",
  "rtsan-standalone",
 ]
 
@@ -303,58 +302,6 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ num = { version = "0.4.3", default-features = false }
 rtsan-standalone = "0.3.0"
 
 [dev-dependencies]
-criterion = "0.7.0"
+criterion = "0.8.1"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "audio-blocks"
 readme = "README.md"
 repository = "https://github.com/neodsp/audio-blocks"
 rust-version = "1.85.0"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 num = { version = "0.4.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = "1.85.0"
 version = "0.6.0"
 
 [dependencies]
-num = { version = "0.4.3", default-features = false }
 rtsan-standalone = "0.3.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Blocks separate allocated capacity from visible size. Resize visible portion wit
 
 ```rust,ignore
 let mut block = AudioBlockPlanar::new(2, 512);  // Allocate 512 frames
-block.set_active_num_frames(256);  // Use only 256
+block.set_num_frames_visible(256);  // Use only 256
 ```
 
 Create views with limited visibility:

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ fn process(block: &mut impl AudioBlockMut<f32>) {
 Three layouts supported:
 
 **Planar** - `[[ch0, ch0, ch0], [ch1, ch1, ch1]]`
-Each channel has its own buffer. Standard for real-time DSP.
+Each channel has its own separate buffer. Standard for real-time DSP. Optimal for SIMD/vectorization.
 
 **Sequential** - `[ch0, ch0, ch0, ch1, ch1, ch1]`
-All samples for channel 0, then all samples for channel 1.
+Single contiguous buffer with all samples for channel 0, then all samples for channel 1. Channel-contiguous in one allocation.
 
 **Interleaved** - `[ch0, ch1, ch0, ch1, ch0, ch1]`
-Channels alternate sample-by-sample. Common in audio APIs.
+Channels alternate sample-by-sample. Common in audio APIs and hardware interfaces.
 
 ## Core Traits
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ Everything from `AudioBlock` plus:
 
 Resizing:
 ```rust,ignore
-fn set_active_size(&mut self, num_channels: u16, num_frames: usize);
-fn set_active_num_channels(&mut self, num_channels: u16);
-fn set_active_num_frames(&mut self, num_frames: usize);
+fn set_visible(&mut self, num_channels: u16, num_frames: usize);
+fn set_num_channels_visible(&mut self, num_channels: u16);
+fn set_num_frames_visible(&mut self, num_frames: usize);
 ```
 
 Mutable access:

--- a/benches/blocks.rs
+++ b/benches/blocks.rs
@@ -1,5 +1,5 @@
 use audio_blocks::{
-    interleaved::AudioBlockInterleaved, ops::AudioBlockOps, planar::AudioBlockPlanar,
+    AudioBlockOpsMut, interleaved::AudioBlockInterleaved, planar::AudioBlockPlanar,
     sequential::AudioBlockSequential,
 };
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/src/interleaved/owned.rs
+++ b/src/interleaved/owned.rs
@@ -155,7 +155,7 @@ impl<S: Sample> AudioBlockInterleaved<S> {
     /// Provides direct access to the underlying memory as an interleaved slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[S] {
         &self.data
@@ -164,7 +164,7 @@ impl<S: Sample> AudioBlockInterleaved<S> {
     /// Provides direct mutable access to the underlying memory as an interleaved slice.
     ///
     /// This function gives mutable access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data_mut(&mut self) -> &mut [S] {
         &mut self.data
@@ -440,7 +440,7 @@ mod tests {
         block.frame_mut(0).copy_from_slice(&[0.0, 1.0, 2.0, 3.0]);
         block.frame_mut(1).copy_from_slice(&[4.0, 5.0, 6.0, 7.0]);
 
-        block.set_visible_size(3, 2);
+        block.set_visible(3, 2);
 
         // single frame
         assert_eq!(block.frame(0), &[0.0, 1.0, 2.0]);
@@ -776,7 +776,7 @@ mod tests {
             assert_eq!(block.frame_iter_mut(i).count(), 3);
         }
 
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 5);
@@ -798,7 +798,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_channels() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_visible_size(3, 10);
+        block.set_visible(3, 10);
     }
 
     #[test]
@@ -806,7 +806,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_frames() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_visible_size(2, 11);
+        block.set_visible(2, 11);
     }
 
     #[test]
@@ -814,7 +814,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_visible_size(1, 10);
+        block.set_visible(1, 10);
         let _ = block.channel_iter(1);
     }
 
@@ -823,7 +823,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         let _ = block.frame_iter(5);
     }
 
@@ -832,7 +832,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel_mut() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_visible_size(1, 10);
+        block.set_visible(1, 10);
         let _ = block.channel_iter_mut(1);
     }
 
@@ -841,7 +841,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame_mut() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         let _ = block.frame_iter_mut(5);
     }
 
@@ -850,7 +850,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let mut block = AudioBlockInterleaved::<f32>::new(3, 6);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         block.frame(5);
     }
 
@@ -859,7 +859,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
         let mut block = AudioBlockInterleaved::<f32>::new(3, 6);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         block.frame_mut(5);
     }
 }

--- a/src/interleaved/owned.rs
+++ b/src/interleaved/owned.rs
@@ -314,13 +314,13 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     type PlanarViewMut = [S; 0];
 
     #[nonblocking]
-    fn set_active_num_channels(&mut self, num_channels: u16) {
+    fn set_num_channels_visible(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
         self.num_channels = num_channels;
     }
 
     #[nonblocking]
-    fn set_active_num_frames(&mut self, num_frames: usize) {
+    fn set_num_frames_visible(&mut self, num_frames: usize) {
         assert!(num_frames <= self.num_frames_allocated);
         self.num_frames = num_frames;
     }
@@ -440,7 +440,7 @@ mod tests {
         block.frame_mut(0).copy_from_slice(&[0.0, 1.0, 2.0, 3.0]);
         block.frame_mut(1).copy_from_slice(&[4.0, 5.0, 6.0, 7.0]);
 
-        block.set_active_size(3, 2);
+        block.set_visible_size(3, 2);
 
         // single frame
         assert_eq!(block.frame(0), &[0.0, 1.0, 2.0]);
@@ -776,7 +776,7 @@ mod tests {
             assert_eq!(block.frame_iter_mut(i).count(), 3);
         }
 
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 5);
@@ -798,7 +798,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_channels() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_active_size(3, 10);
+        block.set_visible_size(3, 10);
     }
 
     #[test]
@@ -806,7 +806,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_frames() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_active_size(2, 11);
+        block.set_visible_size(2, 11);
     }
 
     #[test]
@@ -814,7 +814,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_active_size(1, 10);
+        block.set_visible_size(1, 10);
         let _ = block.channel_iter(1);
     }
 
@@ -823,7 +823,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         let _ = block.frame_iter(5);
     }
 
@@ -832,7 +832,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel_mut() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_active_size(1, 10);
+        block.set_visible_size(1, 10);
         let _ = block.channel_iter_mut(1);
     }
 
@@ -841,7 +841,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame_mut() {
         let mut block = AudioBlockInterleaved::<f32>::new(2, 10);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         let _ = block.frame_iter_mut(5);
     }
 
@@ -850,7 +850,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let mut block = AudioBlockInterleaved::<f32>::new(3, 6);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         block.frame(5);
     }
 
@@ -859,7 +859,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
         let mut block = AudioBlockInterleaved::<f32>::new(3, 6);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         block.frame_mut(5);
     }
 }

--- a/src/interleaved/owned.rs
+++ b/src/interleaved/owned.rs
@@ -43,7 +43,7 @@ pub struct AudioBlockInterleaved<S: Sample> {
     num_frames_allocated: usize,
 }
 
-impl<S: Sample> AudioBlockInterleaved<S> {
+impl<S: Sample + Default> AudioBlockInterleaved<S> {
     /// Creates a new interleaved audio block with the specified dimensions.
     ///
     /// Allocates memory for a new interleaved audio block with exactly the specified
@@ -67,14 +67,16 @@ impl<S: Sample> AudioBlockInterleaved<S> {
             .expect("Multiplication overflow: num_channels * num_frames is too large");
 
         Self {
-            data: vec![S::zero(); total_samples].into_boxed_slice(),
+            data: vec![S::default(); total_samples].into_boxed_slice(),
             num_channels,
             num_frames,
             num_channels_allocated: num_channels,
             num_frames_allocated: num_frames,
         }
     }
+}
 
+impl<S: Sample> AudioBlockInterleaved<S> {
     /// Creates a new audio block by copying data from another [`AudioBlock`].
     ///
     /// Converts any [`AudioBlock`] implementation to an interleaved format by iterating

--- a/src/interleaved/view.rs
+++ b/src/interleaved/view.rs
@@ -506,7 +506,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw() {
+    fn test_from_ptr() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
         let block = unsafe { AudioBlockInterleavedView::<f32>::from_ptr(data.as_mut_ptr(), 2, 5) };
         assert_eq!(block.num_channels(), 2);
@@ -544,7 +544,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw_limited() {
+    fn test_from_ptr_limited() {
         let data = [1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 5.0, 6.0, 0.0, 0.0, 0.0, 0.0];
 
         let block =

--- a/src/interleaved/view.rs
+++ b/src/interleaved/view.rs
@@ -171,7 +171,7 @@ impl<'a, S: Sample> AudioBlockInterleavedView<'a, S> {
     /// Provides direct access to the underlying memory as an interleaved slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[S] {
         &self.data

--- a/src/interleaved/view.rs
+++ b/src/interleaved/view.rs
@@ -98,7 +98,7 @@ impl<'a, S: Sample> AudioBlockInterleavedView<'a, S> {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr` points to valid memory containing at least `num_channels_available * num_frames_available` elements
+    /// - `ptr` points to valid memory containing at least `num_channels_allocated * num_frames_allocated` elements
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]
@@ -117,7 +117,7 @@ impl<'a, S: Sample> AudioBlockInterleavedView<'a, S> {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr` points to valid memory containing at least `num_channels_available * num_frames_available` elements
+    /// - `ptr` points to valid memory containing at least `num_channels_allocated * num_frames_allocated` elements
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]

--- a/src/interleaved/view_mut.rs
+++ b/src/interleaved/view_mut.rs
@@ -102,7 +102,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr` points to valid memory containing at least `num_channels_available * num_frames_available` elements
+    /// - `ptr` points to valid memory containing at least `num_channels_allocated * num_frames_allocated` elements
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]
@@ -123,7 +123,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr` points to valid memory containing at least `num_channels_available * num_frames_available` elements
+    /// - `ptr` points to valid memory containing at least `num_channels_allocated * num_frames_allocated` elements
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]

--- a/src/interleaved/view_mut.rs
+++ b/src/interleaved/view_mut.rs
@@ -202,7 +202,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
     /// Provides direct access to the underlying memory as an interleaved slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[S] {
         &self.data
@@ -211,7 +211,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
     /// Provides direct mutable access to the underlying memory as an interleaved slice.
     ///
     /// This function gives mutable access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data_mut(&mut self) -> &mut [S] {
         &mut self.data
@@ -482,7 +482,7 @@ mod tests {
         let mut block =
             AudioBlockInterleavedViewMut::<f32>::from_slice_limited(&mut data, 3, 2, 4, 3);
 
-        block.set_visible_size(3, 2);
+        block.set_visible(3, 2);
 
         // single frame
         assert_eq!(block.frame(0), &[0.0, 1.0, 2.0]);
@@ -872,7 +872,7 @@ mod tests {
         let mut data = [0.0; 12];
         let mut block =
             AudioBlockInterleavedViewMut::<f32>::from_slice_limited(&mut data, 2, 3, 3, 4);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         block.frame(5);
     }
 
@@ -883,7 +883,7 @@ mod tests {
         let mut data = [0.0; 12];
         let mut block =
             AudioBlockInterleavedViewMut::<f32>::from_slice_limited(&mut data, 2, 3, 3, 4);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         block.frame(5);
     }
 }

--- a/src/interleaved/view_mut.rs
+++ b/src/interleaved/view_mut.rs
@@ -97,7 +97,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
         }
     }
 
-    /// Creates a new audio block from raw parts.
+    /// Creates a new audio block from a pointer.
     ///
     /// # Safety
     ///
@@ -106,7 +106,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]
-    pub unsafe fn from_raw(ptr: *mut S, num_channels: u16, num_frames: usize) -> Self {
+    pub unsafe fn from_ptr(ptr: *mut S, num_channels: u16, num_frames: usize) -> Self {
         Self {
             data: unsafe {
                 std::slice::from_raw_parts_mut(ptr, num_channels as usize * num_frames)
@@ -118,7 +118,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
         }
     }
 
-    /// Creates a new audio block from raw parts with a limited amount of channels and/or frames.
+    /// Creates a new audio block from a pointer with a limited amount of channels and/or frames.
     ///
     /// # Safety
     ///
@@ -127,7 +127,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]
-    pub unsafe fn from_raw_limited(
+    pub unsafe fn from_ptr_limited(
         ptr: *mut S,
         num_channels_visible: u16,
         num_frames_visible: usize,
@@ -804,10 +804,10 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw() {
+    fn test_from_ptr() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
         let block =
-            unsafe { AudioBlockInterleavedViewMut::<f32>::from_raw(data.as_mut_ptr(), 2, 5) };
+            unsafe { AudioBlockInterleavedViewMut::<f32>::from_ptr(data.as_mut_ptr(), 2, 5) };
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated, 2);
         assert_eq!(block.num_frames(), 5);
@@ -843,11 +843,11 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw_limited() {
+    fn test_from_ptr_limited() {
         let mut data = [1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 5.0, 6.0, 0.0, 0.0, 0.0, 0.0];
 
         let mut block = unsafe {
-            AudioBlockInterleavedViewMut::from_raw_limited(data.as_mut_ptr(), 2, 3, 3, 4)
+            AudioBlockInterleavedViewMut::from_ptr_limited(data.as_mut_ptr(), 2, 3, 3, 4)
         };
 
         assert_eq!(block.num_channels(), 2);

--- a/src/interleaved/view_mut.rs
+++ b/src/interleaved/view_mut.rs
@@ -355,13 +355,13 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     type PlanarViewMut = [S; 0];
 
     #[nonblocking]
-    fn set_active_num_channels(&mut self, num_channels: u16) {
+    fn set_num_channels_visible(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
         self.num_channels = num_channels;
     }
 
     #[nonblocking]
-    fn set_active_num_frames(&mut self, num_frames: usize) {
+    fn set_num_frames_visible(&mut self, num_frames: usize) {
         assert!(num_frames <= self.num_frames_allocated);
         self.num_frames = num_frames;
     }
@@ -482,7 +482,7 @@ mod tests {
         let mut block =
             AudioBlockInterleavedViewMut::<f32>::from_slice_limited(&mut data, 3, 2, 4, 3);
 
-        block.set_active_size(3, 2);
+        block.set_visible_size(3, 2);
 
         // single frame
         assert_eq!(block.frame(0), &[0.0, 1.0, 2.0]);
@@ -872,7 +872,7 @@ mod tests {
         let mut data = [0.0; 12];
         let mut block =
             AudioBlockInterleavedViewMut::<f32>::from_slice_limited(&mut data, 2, 3, 3, 4);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         block.frame(5);
     }
 
@@ -883,7 +883,7 @@ mod tests {
         let mut data = [0.0; 12];
         let mut block =
             AudioBlockInterleavedViewMut::<f32>::from_slice_limited(&mut data, 2, 3, 3, 4);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         block.frame(5);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ extern crate core as std;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub use num::Zero;
 pub use ops::AudioBlockOps;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
@@ -30,8 +29,14 @@ pub use planar::AudioBlockPlanarViewMut;
 pub use planar::PlanarPtrAdapter;
 pub use planar::PlanarPtrAdapterMut;
 
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub use mono::AudioBlockMono;
+pub use mono::AudioBlockMonoView;
+pub use mono::AudioBlockMonoViewMut;
+
 pub mod interleaved;
 mod iter;
+pub mod mono;
 pub mod ops;
 pub mod planar;
 pub mod sequential;
@@ -79,8 +84,8 @@ pub enum BlockLayout {
 ///
 /// All numeric types (f32, f64, i16, i32, etc.) automatically implement this trait,
 /// as well as any custom types that satisfy these bounds.
-pub trait Sample: Copy + Zero + 'static {}
-impl<T> Sample for T where T: Copy + Zero + 'static {}
+pub trait Sample: Copy + 'static {}
+impl<T> Sample for T where T: Copy + 'static {}
 
 /// Core trait for audio data access operations across various memory layouts.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub enum BlockLayout {
     ///
     /// Format: `[ch0, ch0, ch0, ..., ch1, ch1, ch1, ...]`
     ///
-    /// Also known as "planar" format in some audio libraries.
+    /// Note: Unlike `Planar`, this uses a single contiguous buffer rather than separate buffers per channel.
     Sequential,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub trait AudioBlock<S: Sample> {
 ///
 /// fn process_audio(audio: &mut impl AudioBlockMut<f32>) {
 ///     // Resize to 2 channels, 1024 frames
-///     audio.set_active_size(2, 1024);
+///     audio.set_visible_size(2, 1024);
 ///
 ///     // Modify individual samples
 ///     *audio.sample_mut(0, 0) = 0.5;
@@ -246,31 +246,31 @@ pub trait AudioBlock<S: Sample> {
 pub trait AudioBlockMut<S: Sample>: AudioBlock<S> {
     type PlanarViewMut: AsRef<[S]> + AsMut<[S]>;
 
-    /// Sets the active size of the audio block to the specified number of channels and frames.
+    /// Sets the visible size of the audio block to the specified number of channels and frames.
     ///
     /// # Panics
     ///
     /// When `num_channels` exceeds [`AudioBlock::num_channels_allocated`] or `num_frames` exceeds [`AudioBlock::num_frames_allocated`].
-    fn set_active_size(&mut self, num_channels: u16, num_frames: usize) {
-        self.set_active_num_channels(num_channels);
-        self.set_active_num_frames(num_frames);
+    fn set_visible_size(&mut self, num_channels: u16, num_frames: usize) {
+        self.set_num_channels_visible(num_channels);
+        self.set_num_frames_visible(num_frames);
     }
 
-    /// Sets the active size of the audio block to the specified number of channels.
+    /// Sets the visible size of the audio block to the specified number of channels.
     ///
     /// This operation is real-time safe but only works up to [`AudioBlock::num_channels_allocated`].
     ///
     /// # Panics
     ///
     /// When `num_channels` exceeds [`AudioBlock::num_channels_allocated`].
-    fn set_active_num_channels(&mut self, num_channels: u16);
+    fn set_num_channels_visible(&mut self, num_channels: u16);
 
-    /// Sets the active size of the audio block to the specified number of frames.
+    /// Sets the visible size of the audio block to the specified number of frames.
     ///
     /// # Panics
     ///
     ///  When `num_frames` exceeds [`AudioBlock::num_frames_allocated`].
-    fn set_active_num_frames(&mut self, num_frames: usize);
+    fn set_num_frames_visible(&mut self, num_frames: usize);
 
     /// Returns a mutable reference to the sample at the specified channel and frame position.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate core as std;
 extern crate std;
 
 pub use ops::AudioBlockOps;
+pub use ops::AudioBlockOpsMut;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub use interleaved::AudioBlockInterleaved;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub trait AudioBlock<S: Sample> {
 ///
 /// fn process_audio(audio: &mut impl AudioBlockMut<f32>) {
 ///     // Resize to 2 channels, 1024 frames
-///     audio.set_visible_size(2, 1024);
+///     audio.set_visible(2, 1024);
 ///
 ///     // Modify individual samples
 ///     *audio.sample_mut(0, 0) = 0.5;
@@ -251,7 +251,7 @@ pub trait AudioBlockMut<S: Sample>: AudioBlock<S> {
     /// # Panics
     ///
     /// When `num_channels` exceeds [`AudioBlock::num_channels_allocated`] or `num_frames` exceeds [`AudioBlock::num_frames_allocated`].
-    fn set_visible_size(&mut self, num_channels: u16, num_frames: usize) {
+    fn set_visible(&mut self, num_channels: u16, num_frames: usize) {
         self.set_num_channels_visible(num_channels);
         self.set_num_frames_visible(num_frames);
     }

--- a/src/mono/mod.rs
+++ b/src/mono/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(any(feature = "std", feature = "alloc"))]
+mod owned;
+mod view;
+mod view_mut;
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+pub use owned::AudioBlockMono;
+pub use view::AudioBlockMonoView;
+pub use view_mut::AudioBlockMonoViewMut;

--- a/src/mono/owned.rs
+++ b/src/mono/owned.rs
@@ -72,6 +72,47 @@ impl<S: Sample + Default> AudioBlockMono<S> {
 }
 
 impl<S: Sample> AudioBlockMono<S> {
+    /// Creates a new mono audio block from a slice of samples.
+    ///
+    /// Copies the provided slice into a new owned mono block.
+    ///
+    /// # Warning
+    ///
+    /// This function allocates memory and should not be used in real-time audio processing contexts.
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - The slice of samples to copy
+    #[blocking]
+    pub fn from_slice(samples: &[S]) -> Self {
+        Self {
+            data: samples.to_vec().into_boxed_slice(),
+            num_frames: samples.len(),
+            num_frames_allocated: samples.len(),
+        }
+    }
+
+    /// Creates a new mono audio block from a slice of samples.
+    ///
+    /// Copies the provided slice into a new owned mono block.
+    ///
+    /// # Warning
+    ///
+    /// This function allocates memory and should not be used in real-time audio processing contexts.
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - The slice of samples to copy
+    /// * `num_frames_visible` - Number of audio frames to expose
+    #[blocking]
+    pub fn from_slice_limited(samples: &[S], num_frames_visible: usize) -> Self {
+        Self {
+            data: samples.to_vec().into_boxed_slice(),
+            num_frames: num_frames_visible,
+            num_frames_allocated: samples.len(),
+        }
+    }
+
     /// Creates a new mono audio block by copying data from another [`AudioBlock`].
     ///
     /// Extracts the first channel from any [`AudioBlock`] implementation.
@@ -102,26 +143,6 @@ impl<S: Sample> AudioBlockMono<S> {
             data: data.into_boxed_slice(),
             num_frames: block.num_frames(),
             num_frames_allocated: block.num_frames(),
-        }
-    }
-
-    /// Creates a new mono audio block from a slice of samples.
-    ///
-    /// Copies the provided slice into a new owned mono block.
-    ///
-    /// # Warning
-    ///
-    /// This function allocates memory and should not be used in real-time audio processing contexts.
-    ///
-    /// # Arguments
-    ///
-    /// * `samples` - The slice of samples to copy
-    #[blocking]
-    pub fn from_slice(samples: &[S]) -> Self {
-        Self {
-            data: samples.to_vec().into_boxed_slice(),
-            num_frames: samples.len(),
-            num_frames_allocated: samples.len(),
         }
     }
 

--- a/src/mono/owned.rs
+++ b/src/mono/owned.rs
@@ -1,0 +1,482 @@
+use rtsan_standalone::{blocking, nonblocking};
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::{boxed::Box, vec, vec::Vec};
+#[cfg(all(feature = "std", not(feature = "alloc")))]
+use std::{boxed::Box, vec, vec::Vec};
+#[cfg(all(feature = "std", feature = "alloc"))]
+use std::{boxed::Box, vec, vec::Vec};
+
+use super::{view::AudioBlockMonoView, view_mut::AudioBlockMonoViewMut};
+use crate::{AudioBlock, AudioBlockMut, Sample};
+
+/// A mono (single-channel) audio block that owns its data.
+///
+/// This is a simplified version of the multi-channel audio blocks, optimized for
+/// mono audio processing with a streamlined API that doesn't require channel indexing.
+///
+/// * **Layout:** `[sample0, sample1, sample2, ...]`
+/// * **Interpretation:** A simple sequence of samples representing a single audio channel.
+/// * **Usage:** Ideal for mono audio processing, side-chain signals, or any single-channel audio data.
+///
+/// # Example
+///
+/// ```
+/// use audio_blocks::*;
+///
+/// let mut block = AudioBlockMono::new(512);
+///
+/// // Fill with a simple ramp
+/// for (i, sample) in block.samples_mut().iter_mut().enumerate() {
+///     *sample = i as f32;
+/// }
+///
+/// assert_eq!(block.sample(0), 0.0);
+/// assert_eq!(block.sample(511), 511.0);
+/// ```
+pub struct AudioBlockMono<S: Sample> {
+    data: Box<[S]>,
+    num_frames: usize,
+    num_frames_allocated: usize,
+}
+
+impl<S: Sample + Default> AudioBlockMono<S> {
+    /// Creates a new mono audio block with the specified number of frames.
+    ///
+    /// Allocates memory for a new mono audio block with exactly the specified
+    /// number of frames. The block is initialized with the default value (zero)
+    /// for the sample type.
+    ///
+    /// Do not use in real-time processes!
+    ///
+    /// # Arguments
+    ///
+    /// * `num_frames` - The number of frames (samples)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use audio_blocks::{mono::AudioBlockMono, AudioBlock};
+    ///
+    /// let block = AudioBlockMono::<f32>::new(1024);
+    /// assert_eq!(block.num_frames(), 1024);
+    /// ```
+    #[blocking]
+    pub fn new(num_frames: usize) -> Self {
+        Self {
+            data: vec![S::default(); num_frames].into_boxed_slice(),
+            num_frames,
+            num_frames_allocated: num_frames,
+        }
+    }
+}
+
+impl<S: Sample> AudioBlockMono<S> {
+    /// Creates a new mono audio block by copying data from another [`AudioBlock`].
+    ///
+    /// Extracts the first channel from any [`AudioBlock`] implementation.
+    /// If the source block has no channels, creates an empty mono block.
+    ///
+    /// # Warning
+    ///
+    /// This function allocates memory and should not be used in real-time audio processing contexts.
+    ///
+    /// # Arguments
+    ///
+    /// * `block` - The source audio block to copy data from (first channel will be used)
+    ///
+    /// # Panics
+    ///
+    /// Panics if the source block has zero channels.
+    #[blocking]
+    pub fn from_block(block: &impl AudioBlock<S>) -> Self {
+        assert!(
+            block.num_channels() > 0,
+            "Cannot create mono block from block with zero channels"
+        );
+
+        let mut data = Vec::with_capacity(block.num_frames());
+        block.channel_iter(0).for_each(|&v| data.push(v));
+
+        Self {
+            data: data.into_boxed_slice(),
+            num_frames: block.num_frames(),
+            num_frames_allocated: block.num_frames(),
+        }
+    }
+
+    /// Creates a new mono audio block from a slice of samples.
+    ///
+    /// Copies the provided slice into a new owned mono block.
+    ///
+    /// # Warning
+    ///
+    /// This function allocates memory and should not be used in real-time audio processing contexts.
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - The slice of samples to copy
+    #[blocking]
+    pub fn from_slice(samples: &[S]) -> Self {
+        Self {
+            data: samples.to_vec().into_boxed_slice(),
+            num_frames: samples.len(),
+            num_frames_allocated: samples.len(),
+        }
+    }
+
+    /// Returns the sample at the specified frame index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if frame index is out of bounds.
+    #[nonblocking]
+    pub fn sample(&self, frame: usize) -> S {
+        assert!(frame < self.num_frames);
+        unsafe { *self.data.get_unchecked(frame) }
+    }
+
+    /// Returns a mutable reference to the sample at the specified frame index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if frame index is out of bounds.
+    #[nonblocking]
+    pub fn sample_mut(&mut self, frame: usize) -> &mut S {
+        assert!(frame < self.num_frames);
+        unsafe { self.data.get_unchecked_mut(frame) }
+    }
+
+    /// Provides direct access to the underlying samples as a slice.
+    ///
+    /// Returns only the visible samples (up to `num_frames`).
+    #[nonblocking]
+    pub fn samples(&self) -> &[S] {
+        &self.data[..self.num_frames]
+    }
+
+    /// Provides direct mutable access to the underlying samples as a slice.
+    ///
+    /// Returns only the visible samples (up to `num_frames`).
+    #[nonblocking]
+    pub fn samples_mut(&mut self) -> &mut [S] {
+        let num_frames = self.num_frames;
+        &mut self.data[..num_frames]
+    }
+
+    /// Provides direct access to all allocated memory, including reserved capacity.
+    ///
+    /// This gives access to the full allocated buffer, including any frames
+    /// beyond the visible range.
+    #[nonblocking]
+    pub fn raw_data(&self) -> &[S] {
+        &self.data
+    }
+
+    /// Provides direct mutable access to all allocated memory, including reserved capacity.
+    ///
+    /// This gives mutable access to the full allocated buffer, including any frames
+    /// beyond the visible range.
+    #[nonblocking]
+    pub fn raw_data_mut(&mut self) -> &mut [S] {
+        &mut self.data
+    }
+
+    /// Creates a view of this mono audio block.
+    #[nonblocking]
+    pub fn view(&self) -> AudioBlockMonoView<'_, S> {
+        AudioBlockMonoView::from_slice_limited(
+            self.raw_data(),
+            self.num_frames,
+            self.num_frames_allocated,
+        )
+    }
+
+    /// Creates a mutable view of this mono audio block.
+    #[nonblocking]
+    pub fn view_mut(&mut self) -> AudioBlockMonoViewMut<'_, S> {
+        let num_frames = self.num_frames;
+        let num_frames_allocated = self.num_frames_allocated;
+        AudioBlockMonoViewMut::from_slice_limited(
+            self.raw_data_mut(),
+            num_frames,
+            num_frames_allocated,
+        )
+    }
+}
+
+impl<S: Sample> AudioBlock<S> for AudioBlockMono<S> {
+    type PlanarView = [S; 0];
+
+    #[nonblocking]
+    fn num_channels(&self) -> u16 {
+        1
+    }
+
+    #[nonblocking]
+    fn num_frames(&self) -> usize {
+        self.num_frames
+    }
+
+    #[nonblocking]
+    fn num_channels_allocated(&self) -> u16 {
+        1
+    }
+
+    #[nonblocking]
+    fn num_frames_allocated(&self) -> usize {
+        self.num_frames_allocated
+    }
+
+    #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Sequential
+    }
+
+    #[nonblocking]
+    fn sample(&self, channel: u16, frame: usize) -> S {
+        assert_eq!(channel, 0, "AudioBlockMono only has channel 0");
+        self.sample(frame)
+    }
+
+    #[nonblocking]
+    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+        assert_eq!(channel, 0, "AudioBlockMono only has channel 0");
+        self.samples().iter()
+    }
+
+    #[nonblocking]
+    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+        core::iter::once(self.samples().iter())
+    }
+
+    #[nonblocking]
+    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+        assert!(frame < self.num_frames);
+        core::iter::once(&self.data[frame])
+    }
+
+    #[nonblocking]
+    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+        self.data.iter().take(self.num_frames).map(core::iter::once)
+    }
+
+    #[nonblocking]
+    fn as_view(&self) -> impl AudioBlock<S> {
+        AudioBlockMonoView::from_slice_limited(
+            self.raw_data(),
+            self.num_frames,
+            self.num_frames_allocated,
+        )
+    }
+}
+
+impl<S: Sample> AudioBlockMut<S> for AudioBlockMono<S> {
+    type PlanarViewMut = [S; 0];
+
+    #[nonblocking]
+    fn set_num_channels_visible(&mut self, num_channels: u16) {
+        assert_eq!(
+            num_channels, 1,
+            "AudioBlockMono can only have 1 channel, got {}",
+            num_channels
+        );
+    }
+
+    #[nonblocking]
+    fn set_num_frames_visible(&mut self, num_frames: usize) {
+        assert!(
+            num_frames <= self.num_frames_allocated,
+            "Cannot set visible frames ({}) beyond allocated frames ({})",
+            num_frames,
+            self.num_frames_allocated
+        );
+        self.num_frames = num_frames;
+    }
+
+    #[nonblocking]
+    fn sample_mut(&mut self, channel: u16, frame: usize) -> &mut S {
+        assert_eq!(channel, 0, "AudioBlockMono only has channel 0");
+        self.sample_mut(frame)
+    }
+
+    #[nonblocking]
+    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+        assert_eq!(channel, 0, "AudioBlockMono only has channel 0");
+        self.samples_mut().iter_mut()
+    }
+
+    #[nonblocking]
+    fn channels_iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+        core::iter::once(self.samples_mut().iter_mut())
+    }
+
+    #[nonblocking]
+    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+        assert!(frame < self.num_frames);
+        let ptr = &mut self.data[frame] as *mut S;
+        // Safety: We're creating a single-item iterator from a valid mutable reference
+        core::iter::once(unsafe { &mut *ptr })
+    }
+
+    #[nonblocking]
+    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+        let num_frames = self.num_frames;
+        self.data.iter_mut().take(num_frames).map(core::iter::once)
+    }
+
+    #[nonblocking]
+    fn as_view_mut(&mut self) -> impl AudioBlockMut<S> {
+        let num_frames = self.num_frames;
+        let num_frames_allocated = self.num_frames_allocated;
+        AudioBlockMonoViewMut::from_slice_limited(
+            self.raw_data_mut(),
+            num_frames,
+            num_frames_allocated,
+        )
+    }
+}
+
+impl<S: Sample + core::fmt::Debug> core::fmt::Debug for AudioBlockMono<S> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "AudioBlockMono {{")?;
+        writeln!(f, "  num_frames: {}", self.num_frames)?;
+        writeln!(f, "  num_frames_allocated: {}", self.num_frames_allocated)?;
+        writeln!(f, "  samples: {:?}", self.samples())?;
+        writeln!(f, "}}")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rtsan_standalone::no_sanitize_realtime;
+
+    #[test]
+    fn test_new() {
+        let block = AudioBlockMono::<f32>::new(1024);
+        assert_eq!(block.num_frames(), 1024);
+        assert_eq!(block.num_frames_allocated(), 1024);
+        assert!(block.samples().iter().all(|&s| s == 0.0));
+    }
+
+    #[test]
+    fn test_from_slice() {
+        let samples = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMono::from_slice(&samples);
+        assert_eq!(block.num_frames(), 5);
+        assert_eq!(block.samples(), &samples);
+    }
+
+    #[test]
+    fn test_sample_access() {
+        let mut block = AudioBlockMono::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+        assert_eq!(block.sample(0), 1.0);
+        assert_eq!(block.sample(2), 3.0);
+        assert_eq!(block.sample(4), 5.0);
+
+        *block.sample_mut(2) = 10.0;
+        assert_eq!(block.sample(2), 10.0);
+    }
+
+    #[test]
+    fn test_iterators() {
+        let mut block = AudioBlockMono::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        let sum: f32 = block.samples().iter().sum();
+        assert_eq!(sum, 15.0);
+
+        for sample in block.samples_mut() {
+            *sample *= 2.0;
+        }
+
+        assert_eq!(block.samples(), &[2.0, 4.0, 6.0, 8.0, 10.0]);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_resize_beyond_allocated() {
+        let mut block = AudioBlockMono::<f32>::new(10);
+        block.set_num_frames_visible(11);
+    }
+
+    #[test]
+    fn test_audio_block_trait() {
+        let block = AudioBlockMono::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        assert_eq!(block.num_channels(), 1);
+        assert_eq!(block.num_frames(), 5);
+
+        // Test channel_iter
+        let channel: Vec<f32> = block.channel_iter(0).copied().collect();
+        assert_eq!(channel, vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        // Test frame_iter
+        let frame: Vec<f32> = block.frame_iter(2).copied().collect();
+        assert_eq!(frame, vec![3.0]);
+    }
+
+    #[test]
+    fn test_audio_block_mut_trait() {
+        let mut block = AudioBlockMono::<f32>::new(5);
+
+        for (i, sample) in block.channel_iter_mut(0).enumerate() {
+            *sample = i as f32;
+        }
+
+        assert_eq!(block.samples(), &[0.0, 1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_channel() {
+        let block = AudioBlockMono::<f32>::new(10);
+        let _ = block.channel_iter(1);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_sample_out_of_bounds() {
+        let block = AudioBlockMono::<f32>::new(10);
+        let _ = block.sample(10);
+    }
+
+    #[test]
+    fn test_from_block() {
+        use crate::AudioBlockInterleaved;
+
+        let mut multi = AudioBlockInterleaved::<f32>::new(2, 5);
+        for (i, sample) in multi.channel_iter_mut(0).enumerate() {
+            *sample = i as f32;
+        }
+
+        let mono = AudioBlockMono::from_block(&multi);
+        assert_eq!(mono.samples(), &[0.0, 1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn test_views() {
+        let mut block = AudioBlockMono::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        // Test immutable view
+        {
+            let view = block.as_view();
+            assert_eq!(view.num_frames(), 5);
+            assert_eq!(view.sample(0, 2), 3.0);
+        }
+
+        // Test mutable view
+        {
+            let mut view_mut = block.as_view_mut();
+            *view_mut.sample_mut(0, 2) = 10.0;
+        }
+
+        assert_eq!(block.sample(2), 10.0);
+    }
+}

--- a/src/mono/owned.rs
+++ b/src/mono/owned.rs
@@ -106,6 +106,7 @@ impl<S: Sample> AudioBlockMono<S> {
     /// * `num_frames_visible` - Number of audio frames to expose
     #[blocking]
     pub fn from_slice_limited(samples: &[S], num_frames_visible: usize) -> Self {
+        assert!(num_frames_visible <= samples.len());
         Self {
             data: samples.to_vec().into_boxed_slice(),
             num_frames: num_frames_visible,

--- a/src/mono/view.rs
+++ b/src/mono/view.rs
@@ -1,0 +1,352 @@
+use rtsan_standalone::nonblocking;
+
+use crate::{AudioBlock, Sample};
+
+/// A read-only view of mono (single-channel) audio data.
+///
+/// This provides a lightweight, non-owning reference to a slice of mono audio samples.
+///
+/// * **Layout:** `[sample0, sample1, sample2, ...]`
+/// * **Interpretation:** A simple sequence of samples representing a single audio channel.
+/// * **Usage:** Ideal for mono audio processing, side-chain signals, or any single-channel audio data.
+///
+/// # Example
+///
+/// ```
+/// use audio_blocks::{mono::AudioBlockMonoView, AudioBlock};
+///
+/// let data = vec![0.0, 1.0, 2.0, 3.0, 4.0];
+/// let block = AudioBlockMonoView::from_slice(&data);
+///
+/// assert_eq!(block.sample(0), 0.0);
+/// assert_eq!(block.sample(4), 4.0);
+/// assert_eq!(block.num_frames(), 5);
+/// ```
+pub struct AudioBlockMonoView<'a, S: Sample> {
+    data: &'a [S],
+    num_frames: usize,
+    num_frames_allocated: usize,
+}
+
+impl<'a, S: Sample> AudioBlockMonoView<'a, S> {
+    /// Creates a new mono audio block view from a slice of audio samples.
+    ///
+    /// # Parameters
+    /// * `data` - The slice containing mono audio samples
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use audio_blocks::{mono::AudioBlockMonoView, AudioBlock};
+    ///
+    /// let samples = [1.0, 2.0, 3.0, 4.0, 5.0];
+    /// let block = AudioBlockMonoView::from_slice(&samples);
+    /// assert_eq!(block.num_frames(), 5);
+    /// ```
+    #[nonblocking]
+    pub fn from_slice(data: &'a [S]) -> Self {
+        let num_frames = data.len();
+        Self {
+            data,
+            num_frames,
+            num_frames_allocated: num_frames,
+        }
+    }
+
+    /// Creates a new mono audio block view from a slice with limited visibility.
+    ///
+    /// This function allows creating a view that exposes only a subset of the allocated frames,
+    /// which is useful for working with a logical section of a larger buffer.
+    ///
+    /// # Parameters
+    /// * `data` - The slice containing mono audio samples
+    /// * `num_frames_visible` - Number of audio frames to expose in the view
+    /// * `num_frames_allocated` - Total number of frames allocated in the data buffer
+    ///
+    /// # Panics
+    /// * Panics if the length of `data` doesn't equal `num_frames_allocated`
+    /// * Panics if `num_frames_visible` exceeds `num_frames_allocated`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use audio_blocks::{mono::AudioBlockMonoView, AudioBlock};
+    ///
+    /// let samples = [1.0, 2.0, 3.0, 4.0, 5.0];
+    /// let block = AudioBlockMonoView::from_slice_limited(&samples, 3, 5);
+    /// assert_eq!(block.num_frames(), 3);
+    /// assert_eq!(block.num_frames_allocated(), 5);
+    /// ```
+    #[nonblocking]
+    pub fn from_slice_limited(
+        data: &'a [S],
+        num_frames_visible: usize,
+        num_frames_allocated: usize,
+    ) -> Self {
+        assert_eq!(data.len(), num_frames_allocated);
+        assert!(num_frames_visible <= num_frames_allocated);
+        Self {
+            data,
+            num_frames: num_frames_visible,
+            num_frames_allocated,
+        }
+    }
+
+    /// Creates a new mono audio block view from a pointer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    /// - `ptr` points to valid memory containing at least `num_frames` elements
+    /// - The memory referenced by `ptr` must be valid for the lifetime of the returned view
+    /// - The memory must not be mutated through other pointers while this view exists
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use audio_blocks::{mono::AudioBlockMonoView, AudioBlock};
+    ///
+    /// let samples = [1.0, 2.0, 3.0, 4.0, 5.0];
+    /// let block = unsafe { AudioBlockMonoView::from_ptr(samples.as_ptr(), 5) };
+    /// assert_eq!(block.num_frames(), 5);
+    /// ```
+    #[nonblocking]
+    pub unsafe fn from_ptr(ptr: *const S, num_frames: usize) -> Self {
+        Self {
+            data: unsafe { std::slice::from_raw_parts(ptr, num_frames) },
+            num_frames,
+            num_frames_allocated: num_frames,
+        }
+    }
+
+    /// Creates a new mono audio block view from a pointer with limited visibility.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    /// - `ptr` points to valid memory containing at least `num_frames_allocated` elements
+    /// - The memory referenced by `ptr` must be valid for the lifetime of the returned view
+    /// - The memory must not be mutated through other pointers while this view exists
+    #[nonblocking]
+    pub unsafe fn from_ptr_limited(
+        ptr: *const S,
+        num_frames_visible: usize,
+        num_frames_allocated: usize,
+    ) -> Self {
+        assert!(num_frames_visible <= num_frames_allocated);
+        Self {
+            data: unsafe { std::slice::from_raw_parts(ptr, num_frames_allocated) },
+            num_frames: num_frames_visible,
+            num_frames_allocated,
+        }
+    }
+
+    /// Returns the sample at the specified frame index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if frame index is out of bounds.
+    #[nonblocking]
+    pub fn sample(&self, frame: usize) -> S {
+        assert!(frame < self.num_frames);
+        unsafe { *self.data.get_unchecked(frame) }
+    }
+
+    /// Provides direct access to the underlying samples as a slice.
+    ///
+    /// Returns only the visible samples (up to `num_frames`).
+    #[nonblocking]
+    pub fn samples(&self) -> &[S] {
+        &self.data[..self.num_frames]
+    }
+
+    /// Provides direct access to all allocated memory, including reserved capacity.
+    #[nonblocking]
+    pub fn raw_data(&self) -> &[S] {
+        self.data
+    }
+
+    #[nonblocking]
+    pub fn view(&self) -> AudioBlockMonoView<'_, S> {
+        AudioBlockMonoView::from_slice_limited(
+            self.data,
+            self.num_frames,
+            self.num_frames_allocated,
+        )
+    }
+}
+
+impl<S: Sample> AudioBlock<S> for AudioBlockMonoView<'_, S> {
+    type PlanarView = [S; 0];
+
+    #[nonblocking]
+    fn num_channels(&self) -> u16 {
+        1
+    }
+
+    #[nonblocking]
+    fn num_frames(&self) -> usize {
+        self.num_frames
+    }
+
+    #[nonblocking]
+    fn num_channels_allocated(&self) -> u16 {
+        1
+    }
+
+    #[nonblocking]
+    fn num_frames_allocated(&self) -> usize {
+        self.num_frames_allocated
+    }
+
+    #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Sequential
+    }
+
+    #[nonblocking]
+    fn sample(&self, channel: u16, frame: usize) -> S {
+        assert_eq!(channel, 0, "AudioBlockMonoView only has channel 0");
+        self.sample(frame)
+    }
+
+    #[nonblocking]
+    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+        assert_eq!(channel, 0, "AudioBlockMonoView only has channel 0");
+        self.samples().iter()
+    }
+
+    #[nonblocking]
+    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+        core::iter::once(self.samples().iter())
+    }
+
+    #[nonblocking]
+    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+        assert!(frame < self.num_frames);
+        core::iter::once(&self.data[frame])
+    }
+
+    #[nonblocking]
+    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+        self.data.iter().take(self.num_frames).map(core::iter::once)
+    }
+
+    #[nonblocking]
+    fn as_view(&self) -> impl AudioBlock<S> {
+        self.view()
+    }
+}
+
+impl<S: Sample + core::fmt::Debug> core::fmt::Debug for AudioBlockMonoView<'_, S> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "AudioBlockMonoView {{")?;
+        writeln!(f, "  num_frames: {}", self.num_frames)?;
+        writeln!(f, "  num_frames_allocated: {}", self.num_frames_allocated)?;
+        writeln!(f, "  samples: {:?}", self.samples())?;
+        writeln!(f, "}}")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rtsan_standalone::no_sanitize_realtime;
+
+    #[test]
+    fn test_from_slice() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoView::from_slice(&data);
+        assert_eq!(block.num_frames(), 5);
+        assert_eq!(block.num_frames_allocated(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_from_slice_limited() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoView::from_slice_limited(&data, 3, 5);
+        assert_eq!(block.num_frames(), 3);
+        assert_eq!(block.num_frames_allocated(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0]);
+        assert_eq!(block.raw_data(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_from_ptr() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = unsafe { AudioBlockMonoView::from_ptr(data.as_ptr(), 5) };
+        assert_eq!(block.num_frames(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_from_ptr_limited() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = unsafe { AudioBlockMonoView::from_ptr_limited(data.as_ptr(), 3, 5) };
+        assert_eq!(block.num_frames(), 3);
+        assert_eq!(block.num_frames_allocated(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_sample_access() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoView::from_slice(&data);
+        assert_eq!(block.sample(0), 1.0);
+        assert_eq!(block.sample(2), 3.0);
+        assert_eq!(block.sample(4), 5.0);
+    }
+
+    #[test]
+    fn test_samples_iter() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoView::from_slice(&data);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_audio_block_trait() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoView::from_slice(&data);
+
+        assert_eq!(block.num_channels(), 1);
+        assert_eq!(block.num_frames(), 5);
+
+        // Test channel_iter
+        let channel: Vec<f32> = block.channel_iter(0).copied().collect();
+        assert_eq!(channel, vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        // Test frame_iter
+        let frame: Vec<f32> = block.frame_iter(2).copied().collect();
+        assert_eq!(frame, vec![3.0]);
+    }
+
+    #[test]
+    fn test_view() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoView::from_slice(&data);
+        let view = block.view();
+        assert_eq!(view.num_frames(), 5);
+        assert_eq!(view.samples(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_sample_out_of_bounds() {
+        let data = [1.0, 2.0, 3.0];
+        let block = AudioBlockMonoView::from_slice(&data);
+        let _ = block.sample(10);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_channel() {
+        let data = [1.0, 2.0, 3.0];
+        let block = AudioBlockMonoView::from_slice(&data);
+        let _ = block.channel_iter(1);
+    }
+}

--- a/src/mono/view_mut.rs
+++ b/src/mono/view_mut.rs
@@ -1,0 +1,520 @@
+use rtsan_standalone::nonblocking;
+
+use super::view::AudioBlockMonoView;
+use crate::{AudioBlock, AudioBlockMut, Sample};
+
+/// A mutable view of mono (single-channel) audio data.
+///
+/// This provides a lightweight, non-owning mutable reference to a slice of mono audio samples.
+///
+/// * **Layout:** `[sample0, sample1, sample2, ...]`
+/// * **Interpretation:** A simple sequence of samples representing a single audio channel.
+/// * **Usage:** Ideal for mono audio processing, side-chain signals, or any single-channel audio data.
+///
+/// # Example
+///
+/// ```
+/// use audio_blocks::{mono::AudioBlockMonoViewMut, AudioBlock};
+///
+/// let mut data = vec![0.0, 1.0, 2.0, 3.0, 4.0];
+/// let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+///
+/// *block.sample_mut(0) = 10.0;
+/// assert_eq!(block.sample(0), 10.0);
+/// ```
+pub struct AudioBlockMonoViewMut<'a, S: Sample> {
+    data: &'a mut [S],
+    num_frames: usize,
+    num_frames_allocated: usize,
+}
+
+impl<'a, S: Sample> AudioBlockMonoViewMut<'a, S> {
+    /// Creates a new mono audio block view from a mutable slice of audio samples.
+    ///
+    /// # Parameters
+    /// * `data` - The mutable slice containing mono audio samples
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use audio_blocks::{mono::AudioBlockMonoViewMut, AudioBlock};
+    ///
+    /// let mut samples = [1.0, 2.0, 3.0, 4.0, 5.0];
+    /// let mut block = AudioBlockMonoViewMut::from_slice(&mut samples);
+    /// assert_eq!(block.num_frames(), 5);
+    /// ```
+    #[nonblocking]
+    pub fn from_slice(data: &'a mut [S]) -> Self {
+        let num_frames = data.len();
+        Self {
+            data,
+            num_frames,
+            num_frames_allocated: num_frames,
+        }
+    }
+
+    /// Creates a new mono audio block view from a mutable slice with limited visibility.
+    ///
+    /// This function allows creating a view that exposes only a subset of the allocated frames,
+    /// which is useful for working with a logical section of a larger buffer.
+    ///
+    /// # Parameters
+    /// * `data` - The mutable slice containing mono audio samples
+    /// * `num_frames_visible` - Number of audio frames to expose in the view
+    /// * `num_frames_allocated` - Total number of frames allocated in the data buffer
+    ///
+    /// # Panics
+    /// * Panics if the length of `data` doesn't equal `num_frames_allocated`
+    /// * Panics if `num_frames_visible` exceeds `num_frames_allocated`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use audio_blocks::{mono::AudioBlockMonoViewMut, AudioBlock};
+    ///
+    /// let mut samples = [1.0, 2.0, 3.0, 4.0, 5.0];
+    /// let mut block = AudioBlockMonoViewMut::from_slice_limited(&mut samples, 3, 5);
+    /// assert_eq!(block.num_frames(), 3);
+    /// assert_eq!(block.num_frames_allocated(), 5);
+    /// ```
+    #[nonblocking]
+    pub fn from_slice_limited(
+        data: &'a mut [S],
+        num_frames_visible: usize,
+        num_frames_allocated: usize,
+    ) -> Self {
+        assert_eq!(data.len(), num_frames_allocated);
+        assert!(num_frames_visible <= num_frames_allocated);
+        Self {
+            data,
+            num_frames: num_frames_visible,
+            num_frames_allocated,
+        }
+    }
+
+    /// Creates a new mono audio block view from a mutable pointer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    /// - `ptr` points to valid memory containing at least `num_frames` elements
+    /// - The memory referenced by `ptr` must be valid for the lifetime of the returned view
+    /// - No other references (mutable or immutable) exist to the same memory
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use audio_blocks::{mono::AudioBlockMonoViewMut, AudioBlock};
+    ///
+    /// let mut samples = [1.0, 2.0, 3.0, 4.0, 5.0];
+    /// let mut block = unsafe { AudioBlockMonoViewMut::from_ptr(samples.as_mut_ptr(), 5) };
+    /// assert_eq!(block.num_frames(), 5);
+    /// ```
+    #[nonblocking]
+    pub unsafe fn from_ptr(ptr: *mut S, num_frames: usize) -> Self {
+        Self {
+            data: unsafe { std::slice::from_raw_parts_mut(ptr, num_frames) },
+            num_frames,
+            num_frames_allocated: num_frames,
+        }
+    }
+
+    /// Creates a new mono audio block view from a mutable pointer with limited visibility.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    /// - `ptr` points to valid memory containing at least `num_frames_allocated` elements
+    /// - The memory referenced by `ptr` must be valid for the lifetime of the returned view
+    /// - No other references (mutable or immutable) exist to the same memory
+    #[nonblocking]
+    pub unsafe fn from_ptr_limited(
+        ptr: *mut S,
+        num_frames_visible: usize,
+        num_frames_allocated: usize,
+    ) -> Self {
+        assert!(num_frames_visible <= num_frames_allocated);
+        Self {
+            data: unsafe { std::slice::from_raw_parts_mut(ptr, num_frames_allocated) },
+            num_frames: num_frames_visible,
+            num_frames_allocated,
+        }
+    }
+
+    /// Returns the sample at the specified frame index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if frame index is out of bounds.
+    #[nonblocking]
+    pub fn sample(&self, frame: usize) -> S {
+        assert!(frame < self.num_frames);
+        unsafe { *self.data.get_unchecked(frame) }
+    }
+
+    /// Returns a mutable reference to the sample at the specified frame index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if frame index is out of bounds.
+    #[nonblocking]
+    pub fn sample_mut(&mut self, frame: usize) -> &mut S {
+        assert!(frame < self.num_frames);
+        unsafe { self.data.get_unchecked_mut(frame) }
+    }
+
+    /// Provides direct access to the underlying samples as a slice.
+    ///
+    /// Returns only the visible samples (up to `num_frames`).
+    #[nonblocking]
+    pub fn samples(&self) -> &[S] {
+        &self.data[..self.num_frames]
+    }
+
+    /// Provides direct mutable access to the underlying samples as a slice.
+    ///
+    /// Returns only the visible samples (up to `num_frames`).
+    #[nonblocking]
+    pub fn samples_mut(&mut self) -> &mut [S] {
+        let num_frames = self.num_frames;
+        &mut self.data[..num_frames]
+    }
+
+    /// Provides direct access to all allocated memory, including reserved capacity.
+    #[nonblocking]
+    pub fn raw_data(&self) -> &[S] {
+        self.data
+    }
+
+    /// Provides direct mutable access to all allocated memory, including reserved capacity.
+    #[nonblocking]
+    pub fn raw_data_mut(&mut self) -> &mut [S] {
+        self.data
+    }
+
+    #[nonblocking]
+    pub fn view(&self) -> AudioBlockMonoView<'_, S> {
+        AudioBlockMonoView::from_slice_limited(
+            self.data,
+            self.num_frames,
+            self.num_frames_allocated,
+        )
+    }
+
+    #[nonblocking]
+    pub fn view_mut(&mut self) -> AudioBlockMonoViewMut<'_, S> {
+        AudioBlockMonoViewMut::from_slice_limited(
+            self.data,
+            self.num_frames,
+            self.num_frames_allocated,
+        )
+    }
+}
+
+impl<S: Sample> AudioBlock<S> for AudioBlockMonoViewMut<'_, S> {
+    type PlanarView = [S; 0];
+
+    #[nonblocking]
+    fn num_channels(&self) -> u16 {
+        1
+    }
+
+    #[nonblocking]
+    fn num_frames(&self) -> usize {
+        self.num_frames
+    }
+
+    #[nonblocking]
+    fn num_channels_allocated(&self) -> u16 {
+        1
+    }
+
+    #[nonblocking]
+    fn num_frames_allocated(&self) -> usize {
+        self.num_frames_allocated
+    }
+
+    #[nonblocking]
+    fn layout(&self) -> crate::BlockLayout {
+        crate::BlockLayout::Sequential
+    }
+
+    #[nonblocking]
+    fn sample(&self, channel: u16, frame: usize) -> S {
+        assert_eq!(channel, 0, "AudioBlockMonoViewMut only has channel 0");
+        self.sample(frame)
+    }
+
+    #[nonblocking]
+    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+        assert_eq!(channel, 0, "AudioBlockMonoViewMut only has channel 0");
+        self.samples().iter()
+    }
+
+    #[nonblocking]
+    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+        core::iter::once(self.samples().iter())
+    }
+
+    #[nonblocking]
+    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+        assert!(frame < self.num_frames);
+        core::iter::once(&self.data[frame])
+    }
+
+    #[nonblocking]
+    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+        self.data.iter().take(self.num_frames).map(core::iter::once)
+    }
+
+    #[nonblocking]
+    fn as_view(&self) -> impl AudioBlock<S> {
+        self.view()
+    }
+}
+
+impl<S: Sample> AudioBlockMut<S> for AudioBlockMonoViewMut<'_, S> {
+    type PlanarViewMut = [S; 0];
+
+    #[nonblocking]
+    fn set_num_channels_visible(&mut self, num_channels: u16) {
+        assert_eq!(
+            num_channels, 1,
+            "AudioBlockMonoViewMut can only have 1 channel, got {}",
+            num_channels
+        );
+    }
+
+    #[nonblocking]
+    fn set_num_frames_visible(&mut self, num_frames: usize) {
+        assert!(num_frames <= self.num_frames_allocated);
+        self.num_frames = num_frames;
+    }
+
+    #[nonblocking]
+    fn sample_mut(&mut self, channel: u16, frame: usize) -> &mut S {
+        assert_eq!(channel, 0, "AudioBlockMonoViewMut only has channel 0");
+        self.sample_mut(frame)
+    }
+
+    #[nonblocking]
+    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+        assert_eq!(channel, 0, "AudioBlockMonoViewMut only has channel 0");
+        self.samples_mut().iter_mut()
+    }
+
+    #[nonblocking]
+    fn channels_iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+        core::iter::once(self.samples_mut().iter_mut())
+    }
+
+    #[nonblocking]
+    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+        assert!(frame < self.num_frames);
+        let ptr = &mut self.data[frame] as *mut S;
+        core::iter::once(unsafe { &mut *ptr })
+    }
+
+    #[nonblocking]
+    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+        let num_frames = self.num_frames;
+        self.data.iter_mut().take(num_frames).map(core::iter::once)
+    }
+
+    #[nonblocking]
+    fn as_view_mut(&mut self) -> impl AudioBlockMut<S> {
+        self.view_mut()
+    }
+}
+
+impl<S: Sample + core::fmt::Debug> core::fmt::Debug for AudioBlockMonoViewMut<'_, S> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "AudioBlockMonoViewMut {{")?;
+        writeln!(f, "  num_frames: {}", self.num_frames)?;
+        writeln!(f, "  num_frames_allocated: {}", self.num_frames_allocated)?;
+        writeln!(f, "  samples: {:?}", self.samples())?;
+        writeln!(f, "}}")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rtsan_standalone::no_sanitize_realtime;
+
+    #[test]
+    fn test_from_slice() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoViewMut::from_slice(&mut data);
+        assert_eq!(block.num_frames(), 5);
+        assert_eq!(block.num_frames_allocated(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_from_slice_limited() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoViewMut::from_slice_limited(&mut data, 3, 5);
+        assert_eq!(block.num_frames(), 3);
+        assert_eq!(block.num_frames_allocated(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0]);
+        assert_eq!(block.raw_data(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_from_ptr() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = unsafe { AudioBlockMonoViewMut::from_ptr(data.as_mut_ptr(), 5) };
+        assert_eq!(block.num_frames(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_from_ptr_limited() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = unsafe { AudioBlockMonoViewMut::from_ptr_limited(data.as_mut_ptr(), 3, 5) };
+        assert_eq!(block.num_frames(), 3);
+        assert_eq!(block.num_frames_allocated(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_sample_access() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+        assert_eq!(block.sample(0), 1.0);
+        assert_eq!(block.sample(2), 3.0);
+        assert_eq!(block.sample(4), 5.0);
+
+        *block.sample_mut(2) = 10.0;
+        assert_eq!(block.sample(2), 10.0);
+    }
+
+    #[test]
+    fn test_samples_iter() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        for sample in block.samples_mut() {
+            *sample *= 2.0;
+        }
+
+        assert_eq!(block.samples(), &[2.0, 4.0, 6.0, 8.0, 10.0]);
+    }
+
+    #[test]
+    fn test_fill_and_clear() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+
+        block.samples_mut().fill(0.5);
+        assert_eq!(block.samples(), &[0.5, 0.5, 0.5, 0.5, 0.5]);
+
+        for s in block.samples_mut() {
+            *s = 0.0;
+        }
+        assert_eq!(block.samples(), &[0.0, 0.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_audio_block_trait() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let block = AudioBlockMonoViewMut::from_slice(&mut data);
+
+        assert_eq!(block.num_channels(), 1);
+        assert_eq!(block.num_frames(), 5);
+
+        // Test channel_iter
+        let channel: Vec<f32> = block.channel_iter(0).copied().collect();
+        assert_eq!(channel, vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+
+        // Test frame_iter
+        let frame: Vec<f32> = block.frame_iter(2).copied().collect();
+        assert_eq!(frame, vec![3.0]);
+    }
+
+    #[test]
+    fn test_audio_block_mut_trait() {
+        let mut data = [0.0, 0.0, 0.0, 0.0, 0.0];
+        let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+
+        for (i, sample) in block.channel_iter_mut(0).enumerate() {
+            *sample = i as f32;
+        }
+
+        assert_eq!(block.samples(), &[0.0, 1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn test_set_num_frames_visible() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+
+        block.set_num_frames_visible(3);
+        assert_eq!(block.num_frames(), 3);
+        assert_eq!(block.num_frames_allocated(), 5);
+        assert_eq!(block.samples(), &[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_views() {
+        let mut data = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+
+        // Test immutable view
+        {
+            let view = block.view();
+            assert_eq!(view.num_frames(), 5);
+            assert_eq!(view.samples(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+        }
+
+        // Test mutable view
+        {
+            let mut view_mut = block.view_mut();
+            *view_mut.sample_mut(2) = 10.0;
+        }
+
+        assert_eq!(block.sample(2), 10.0);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_sample_out_of_bounds() {
+        let mut data = [1.0, 2.0, 3.0];
+        let block = AudioBlockMonoViewMut::from_slice(&mut data);
+        let _ = block.sample(10);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_sample_mut_out_of_bounds() {
+        let mut data = [1.0, 2.0, 3.0];
+        let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+        let _ = block.sample_mut(10);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_wrong_channel() {
+        let mut data = [1.0, 2.0, 3.0];
+        let block = AudioBlockMonoViewMut::from_slice(&mut data);
+        let _ = block.channel_iter(1);
+    }
+
+    #[test]
+    #[should_panic]
+    #[no_sanitize_realtime]
+    fn test_set_num_frames_beyond_allocated() {
+        let mut data = [1.0, 2.0, 3.0];
+        let mut block = AudioBlockMonoViewMut::from_slice(&mut data);
+        block.set_num_frames_visible(10);
+    }
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -47,7 +47,7 @@ impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOps<S> for B {
     fn copy_from_block_resize(&mut self, block: &impl AudioBlock<S>) {
         assert!(block.num_channels() <= self.num_channels_allocated());
         assert!(block.num_frames() <= self.num_frames_allocated());
-        self.set_active_size(block.num_channels(), block.num_frames());
+        self.set_visible_size(block.num_channels(), block.num_frames());
 
         for ch in 0..self.num_channels() {
             for (sample_mut, sample) in self.channel_iter_mut(ch).zip(block.channel_iter(ch)) {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,13 +1,27 @@
 use rtsan_standalone::nonblocking;
 
-use crate::{AudioBlock, AudioBlockMut, BlockLayout, Sample};
+use crate::{
+    AudioBlock, AudioBlockMut, BlockLayout, Sample,
+    mono::{AudioBlockMonoView, AudioBlockMonoViewMut},
+};
 
 pub trait AudioBlockOps<S: Sample> {
+    /// Mix all channels to mono by averaging them.
+    /// Panics if source and destination don't have the same number of frames.
+    fn mix_to_mono(&self, dest: &mut AudioBlockMonoViewMut<S>)
+    where
+        S: std::ops::AddAssign + std::ops::Div<Output = S> + From<u16>;
+}
+
+pub trait AudioBlockOpsMut<S: Sample> {
     /// Copy will panic if blocks don't have the exact same size
     fn copy_from_block(&mut self, block: &impl AudioBlock<S>);
     /// Destination block will take over the size from source block.
     /// Panics if destination block has not enough memory allocated to grow.
     fn copy_from_block_resize(&mut self, block: &impl AudioBlock<S>);
+    /// Copy a mono block to all channels of this block.
+    /// Panics if blocks don't have the same number of frames.
+    fn copy_mono_to_all_channels(&mut self, mono: &AudioBlockMonoView<S>);
     /// Gives access to all samples in the block.
     fn for_each(&mut self, f: impl FnMut(&mut S));
     /// Gives access to all samples in the block.
@@ -29,7 +43,27 @@ pub trait AudioBlockOps<S: Sample> {
     fn fill_with(&mut self, sample: S);
 }
 
-impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOps<S> for B {
+impl<S: Sample, B: AudioBlock<S>> AudioBlockOps<S> for B {
+    #[nonblocking]
+    fn mix_to_mono(&self, dest: &mut AudioBlockMonoViewMut<S>)
+    where
+        S: std::ops::AddAssign + std::ops::Div<Output = S> + From<u16>,
+    {
+        assert_eq!(self.num_frames(), dest.num_frames());
+
+        let num_channels = S::from(self.num_channels());
+
+        for frame in 0..self.num_frames() {
+            let mut sum = *self.frame_iter(frame).next().unwrap();
+            for sample in self.frame_iter(frame).skip(1) {
+                sum += *sample;
+            }
+            *dest.sample_mut(frame) = sum / num_channels;
+        }
+    }
+}
+
+impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOpsMut<S> for B {
     #[nonblocking]
     fn copy_from_block(&mut self, block: &impl AudioBlock<S>) {
         assert_eq!(block.num_channels(), self.num_channels());
@@ -46,9 +80,18 @@ impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOps<S> for B {
         assert!(block.num_channels() <= self.num_channels_allocated());
         assert!(block.num_frames() <= self.num_frames_allocated());
         self.set_visible(block.num_channels(), block.num_frames());
+        for (this_channel, other_channel) in self.channels_iter_mut().zip(block.channels_iter()) {
+            for (sample_mut, sample) in this_channel.zip(other_channel) {
+                *sample_mut = *sample;
+            }
+        }
+    }
 
-        for ch in 0..self.num_channels() {
-            for (sample_mut, sample) in self.channel_iter_mut(ch).zip(block.channel_iter(ch)) {
+    #[nonblocking]
+    fn copy_mono_to_all_channels(&mut self, mono: &AudioBlockMonoView<S>) {
+        assert_eq!(mono.num_frames(), self.num_frames());
+        for channel in self.channels_iter_mut() {
+            for (sample_mut, sample) in channel.zip(mono.samples()) {
                 *sample_mut = *sample;
             }
         }
@@ -361,6 +404,51 @@ mod tests {
         assert_eq!(
             block.channel_iter(1).copied().collect::<Vec<_>>(),
             vec![0.0, 0.0, 0.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn test_mix_to_mono() {
+        use crate::mono::AudioBlockMonoViewMut;
+
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let block = AudioBlockSequentialView::from_slice(&data, 2, 4);
+
+        let mut mono_data = [0.0; 4];
+        let mut mono = AudioBlockMonoViewMut::from_slice(&mut mono_data);
+
+        block.mix_to_mono(&mut mono);
+
+        assert_eq!(mono.num_frames(), 4);
+        assert_eq!(
+            mono.samples().iter().copied().collect::<Vec<_>>(),
+            vec![3.0, 4.0, 5.0, 6.0] // (1+5)/2, (2+6)/2, (3+7)/2, (4+8)/2
+        );
+    }
+
+    #[test]
+    fn test_copy_mono_to_all_channels() {
+        use crate::mono::AudioBlockMonoView;
+
+        let mono_data = [1.0, 2.0, 3.0, 4.0];
+        let mono = AudioBlockMonoView::from_slice(&mono_data);
+
+        let mut data = [0.0; 12];
+        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 3, 4);
+
+        block.copy_mono_to_all_channels(&mono);
+
+        assert_eq!(
+            block.channel_iter(0).copied().collect::<Vec<_>>(),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+        assert_eq!(
+            block.channel_iter(1).copied().collect::<Vec<_>>(),
+            vec![1.0, 2.0, 3.0, 4.0]
+        );
+        assert_eq!(
+            block.channel_iter(2).copied().collect::<Vec<_>>(),
+            vec![1.0, 2.0, 3.0, 4.0]
         );
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -14,11 +14,13 @@ pub trait AudioBlockOps<S: Sample> {
 }
 
 pub trait AudioBlockOpsMut<S: Sample> {
-    /// Copy will panic if blocks don't have the exact same size
+    /// Copy samples from source block, clamping to the smaller dimensions.
+    /// Resizes destination to `min(src, dst)` channels and frames.
+    /// Never panics - safely handles mismatched block sizes.
     fn copy_from_block(&mut self, block: &impl AudioBlock<S>);
-    /// Destination block will take over the size from source block.
-    /// Panics if destination block has not enough memory allocated to grow.
-    fn copy_from_block_resize(&mut self, block: &impl AudioBlock<S>);
+    /// Copy samples from source block, requiring exact size match.
+    /// Panics if source and destination don't have identical channels and frames.
+    fn copy_from_block_exact(&mut self, block: &impl AudioBlock<S>);
     /// Copy a mono block to all channels of this block.
     /// Panics if blocks don't have the same number of frames.
     fn copy_mono_to_all_channels(&mut self, mono: &AudioBlockMonoView<S>);
@@ -66,22 +68,23 @@ impl<S: Sample, B: AudioBlock<S>> AudioBlockOps<S> for B {
 impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOpsMut<S> for B {
     #[nonblocking]
     fn copy_from_block(&mut self, block: &impl AudioBlock<S>) {
-        assert_eq!(block.num_channels(), self.num_channels());
-        assert_eq!(block.num_frames(), self.num_frames());
-        for ch in 0..self.num_channels() {
-            for (sample_mut, sample) in self.channel_iter_mut(ch).zip(block.channel_iter(ch)) {
+        let channels = self.num_channels().min(block.num_channels());
+        let frames = self.num_frames().min(block.num_frames());
+
+        self.set_visible(channels, frames);
+        for (this_channel, other_channel) in self.channels_iter_mut().zip(block.channels_iter()) {
+            for (sample_mut, sample) in this_channel.zip(other_channel) {
                 *sample_mut = *sample;
             }
         }
     }
 
     #[nonblocking]
-    fn copy_from_block_resize(&mut self, block: &impl AudioBlock<S>) {
-        assert!(block.num_channels() <= self.num_channels_allocated());
-        assert!(block.num_frames() <= self.num_frames_allocated());
-        self.set_visible(block.num_channels(), block.num_frames());
-        for (this_channel, other_channel) in self.channels_iter_mut().zip(block.channels_iter()) {
-            for (sample_mut, sample) in this_channel.zip(other_channel) {
+    fn copy_from_block_exact(&mut self, block: &impl AudioBlock<S>) {
+        assert_eq!(block.num_channels(), self.num_channels());
+        assert_eq!(block.num_frames(), self.num_frames());
+        for ch in 0..self.num_channels() {
+            for (sample_mut, sample) in self.channel_iter_mut(ch).zip(block.channel_iter(ch)) {
                 *sample_mut = *sample;
             }
         }
@@ -236,12 +239,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_copy_from() {
+    fn test_copy_from_block_resizes_to_smaller() {
+        // Destination is larger than source - should resize to source size
         let mut data = [0.0; 15];
-        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 3, 5);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 3);
         let view =
-            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
-        block.copy_from_block_resize(&view);
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2);
+        block.copy_from_block(&view);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 4);
@@ -259,17 +263,54 @@ mod tests {
     }
 
     #[test]
-    fn test_copy_from_exact() {
-        let mut data = [0.0; 8];
-        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2, 4);
+    fn test_copy_from_block_clamps_to_dest_size() {
+        // Source is larger than destination - should clamp to destination size
+        let mut data = [0.0; 4]; // 2 channels, 2 frames
+        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 2);
         let view =
-            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2);
         block.copy_from_block(&view);
 
         assert_eq!(block.num_channels(), 2);
+        assert_eq!(block.num_frames(), 2);
+        // Only first 2 frames copied from each channel
+        assert_eq!(
+            block.channel_iter(0).copied().collect::<Vec<_>>(),
+            vec![0.0, 1.0]
+        );
+        assert_eq!(
+            block.channel_iter(1).copied().collect::<Vec<_>>(),
+            vec![4.0, 5.0]
+        );
+    }
+
+    #[test]
+    fn test_copy_from_block_clamps_channels() {
+        // Source has more channels than destination
+        let mut data = [0.0; 4]; // 1 channel, 4 frames
+        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 1);
+        let view =
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2);
+        block.copy_from_block(&view);
+
+        assert_eq!(block.num_channels(), 1);
         assert_eq!(block.num_frames(), 4);
-        assert_eq!(block.num_channels_allocated(), 2);
-        assert_eq!(block.num_frames_allocated(), 4);
+        assert_eq!(
+            block.channel_iter(0).copied().collect::<Vec<_>>(),
+            vec![0.0, 1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn test_copy_from_block_exact() {
+        let mut data = [0.0; 8];
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2);
+        let view =
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2);
+        block.copy_from_block_exact(&view);
+
+        assert_eq!(block.num_channels(), 2);
+        assert_eq!(block.num_frames(), 4);
 
         assert_eq!(
             block.channel_iter(0).copied().collect::<Vec<_>>(),
@@ -284,51 +325,29 @@ mod tests {
     #[test]
     #[should_panic]
     #[no_sanitize_realtime]
-    fn test_copy_data_wrong_channels() {
-        let mut data = [0.0; 5];
-        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 1, 5);
-        let view =
-            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
-        block.copy_from_block_resize(&view);
-    }
-
-    #[test]
-    #[should_panic]
-    #[no_sanitize_realtime]
-    fn test_copy_data_wrong_frames() {
-        let mut data = [0.0; 9];
-        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 3, 3);
-        let view =
-            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
-        block.copy_from_block(&view);
-    }
-
-    #[test]
-    #[should_panic]
-    #[no_sanitize_realtime]
-    fn test_copy_data_exact_wrong_channels() {
+    fn test_copy_from_block_exact_wrong_channels() {
         let mut data = [0.0; 12];
-        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 3, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 3);
         let view =
-            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
-        block.copy_from_block(&view);
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2);
+        block.copy_from_block_exact(&view);
     }
 
     #[test]
     #[should_panic]
     #[no_sanitize_realtime]
-    fn test_copy_data_exact_wrong_frames() {
+    fn test_copy_from_block_exact_wrong_frames() {
         let mut data = [0.0; 10];
-        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2);
         let view =
-            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2, 4);
-        block.copy_from_block(&view);
+            AudioBlockSequentialView::from_slice(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], 2);
+        block.copy_from_block_exact(&view);
     }
 
     #[test]
     fn test_for_each() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
-        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 2, 4);
+        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 2);
 
         let mut i = 0;
         let mut c_exp = 0;
@@ -345,7 +364,7 @@ mod tests {
         });
 
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
-        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2, 4);
+        let mut block = AudioBlockInterleavedViewMut::from_slice(&mut data, 2);
 
         let mut i = 0;
         let mut f_exp = 0;
@@ -382,7 +401,7 @@ mod tests {
     #[test]
     fn test_clear() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
-        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 2, 4);
+        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 2);
 
         block.fill_with(1.0);
 
@@ -412,7 +431,7 @@ mod tests {
         use crate::mono::AudioBlockMonoViewMut;
 
         let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-        let block = AudioBlockSequentialView::from_slice(&data, 2, 4);
+        let block = AudioBlockSequentialView::from_slice(&data, 2);
 
         let mut mono_data = [0.0; 4];
         let mut mono = AudioBlockMonoViewMut::from_slice(&mut mono_data);
@@ -434,7 +453,7 @@ mod tests {
         let mono = AudioBlockMonoView::from_slice(&mono_data);
 
         let mut data = [0.0; 12];
-        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 3, 4);
+        let mut block = AudioBlockSequentialViewMut::from_slice(&mut data, 3);
 
         block.copy_mono_to_all_channels(&mono);
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -43,6 +43,10 @@ pub trait AudioBlockOpsMut<S: Sample> {
     fn enumerate_including_non_visible(&mut self, f: impl FnMut(u16, usize, &mut S));
     /// Sets all samples in the block to the specified value
     fn fill_with(&mut self, sample: S);
+    /// Sets all samples in the block to the default value (zero for numeric types)
+    fn clear(&mut self)
+    where
+        S: Default;
 }
 
 impl<S: Sample, B: AudioBlock<S>> AudioBlockOps<S> for B {
@@ -223,6 +227,14 @@ impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOpsMut<S> for B {
     #[nonblocking]
     fn fill_with(&mut self, sample: S) {
         self.for_each_including_non_visible(|v| *v = sample);
+    }
+
+    #[nonblocking]
+    fn clear(&mut self)
+    where
+        S: Default,
+    {
+        self.fill_with(S::default());
     }
 }
 
@@ -414,7 +426,7 @@ mod tests {
             vec![1.0, 1.0, 1.0, 1.0]
         );
 
-        block.fill_with(0.0);
+        block.clear();
 
         assert_eq!(
             block.channel_iter(0).copied().collect::<Vec<_>>(),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -27,8 +27,6 @@ pub trait AudioBlockOps<S: Sample> {
     fn enumerate_including_non_visible(&mut self, f: impl FnMut(u16, usize, &mut S));
     /// Sets all samples in the block to the specified value
     fn fill_with(&mut self, sample: S);
-    /// Sets all samples in the block to zero
-    fn clear(&mut self);
 }
 
 impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOps<S> for B {
@@ -179,11 +177,6 @@ impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOps<S> for B {
     #[nonblocking]
     fn fill_with(&mut self, sample: S) {
         self.for_each_including_non_visible(|v| *v = sample);
-    }
-
-    #[nonblocking]
-    fn clear(&mut self) {
-        self.fill_with(S::zero());
     }
 }
 
@@ -359,7 +352,7 @@ mod tests {
             vec![1.0, 1.0, 1.0, 1.0]
         );
 
-        block.clear();
+        block.fill_with(0.0);
 
         assert_eq!(
             block.channel_iter(0).copied().collect::<Vec<_>>(),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -47,7 +47,7 @@ impl<S: Sample, B: AudioBlockMut<S>> AudioBlockOps<S> for B {
     fn copy_from_block_resize(&mut self, block: &impl AudioBlock<S>) {
         assert!(block.num_channels() <= self.num_channels_allocated());
         assert!(block.num_frames() <= self.num_frames_allocated());
-        self.set_visible_size(block.num_channels(), block.num_frames());
+        self.set_visible(block.num_channels(), block.num_frames());
 
         for ch in 0..self.num_channels() {
             for (sample_mut, sample) in self.channel_iter_mut(ch).zip(block.channel_iter(ch)) {

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -11,7 +11,7 @@ use crate::{AudioBlock, AudioBlockMut, Sample};
 
 use super::{view::AudioBlockPlanarView, view_mut::AudioBlockPlanarViewMut};
 
-/// A planar / seperate-channel audio block that owns its data.
+/// A planar / separate-channel audio block that owns its data.
 ///
 /// * **Layout:** `[[ch0, ch0, ch0], [ch1, ch1, ch1]]`
 /// * **Interpretation:** Each channel has its own separate buffer or array.

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -40,7 +40,7 @@ pub struct AudioBlockPlanar<S: Sample> {
     num_frames_allocated: usize,
 }
 
-impl<S: Sample> AudioBlockPlanar<S> {
+impl<S: Sample + Default> AudioBlockPlanar<S> {
     /// Creates a new audio block with the specified dimensions.
     ///
     /// Allocates memory for a new planar audio block with exactly the specified
@@ -60,7 +60,7 @@ impl<S: Sample> AudioBlockPlanar<S> {
     #[blocking]
     pub fn new(num_channels: u16, num_frames: usize) -> Self {
         Self {
-            data: vec![vec![S::zero(); num_frames].into_boxed_slice(); num_channels as usize]
+            data: vec![vec![S::default(); num_frames].into_boxed_slice(); num_channels as usize]
                 .into_boxed_slice(),
             num_channels,
             num_frames,
@@ -68,7 +68,9 @@ impl<S: Sample> AudioBlockPlanar<S> {
             num_frames_allocated: num_frames,
         }
     }
+}
 
+impl<S: Sample> AudioBlockPlanar<S> {
     /// Creates a new audio block by copying data from another [`AudioBlock`].
     ///
     /// Converts any [`AudioBlock`] implementation to a planar format by iterating

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -144,7 +144,7 @@ impl<S: Sample> AudioBlockPlanar<S> {
     /// Provides direct access to the underlying memory.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[Box<[S]>] {
         &self.data
@@ -153,7 +153,7 @@ impl<S: Sample> AudioBlockPlanar<S> {
     /// Provides direct access to the underlying memory.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data_mut(&mut self) -> &mut [Box<[S]>] {
         &mut self.data
@@ -230,7 +230,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
-            // Limit to the active number of channels
+            // Limit to the visible number of channels
             .take(self.num_channels as usize)
             // For each channel slice, create an iterator over its samples
             .map(move |channel_data| channel_data.as_ref().iter().take(num_frames))
@@ -414,7 +414,7 @@ mod tests {
         block.channel_mut(0).copy_from_slice(&[0.0, 1.0, 2.0, 3.0]);
         block.channel_mut(1).copy_from_slice(&[4.0, 5.0, 6.0, 7.0]);
 
-        block.set_visible_size(2, 3);
+        block.set_visible(2, 3);
 
         // single frame
         assert_eq!(block.channel(0), &[0.0, 1.0, 2.0]);
@@ -581,7 +581,7 @@ mod tests {
     #[test]
     fn test_frame_iters() {
         let mut block = AudioBlockPlanar::<f32>::new(3, 6);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
 
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames_iter();
@@ -725,8 +725,8 @@ mod tests {
             assert_eq!(block.frame_iter_mut(i).count(), 3);
         }
 
-        block.set_visible_size(3, 10);
-        block.set_visible_size(2, 5);
+        block.set_visible(3, 10);
+        block.set_visible(2, 5);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 5);
@@ -748,7 +748,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_channels() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_visible_size(3, 10);
+        block.set_visible(3, 10);
     }
 
     #[test]
@@ -756,7 +756,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_frames() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_visible_size(2, 11);
+        block.set_visible(2, 11);
     }
 
     #[test]
@@ -764,7 +764,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_visible_size(1, 10);
+        block.set_visible(1, 10);
         let _ = block.channel_iter(1);
     }
 
@@ -773,7 +773,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         let _ = block.frame_iter(5);
     }
 
@@ -782,7 +782,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel_mut() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_visible_size(1, 10);
+        block.set_visible(1, 10);
         let _ = block.channel_iter_mut(1);
     }
 
@@ -791,7 +791,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame_mut() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         let _ = block.frame_iter_mut(5);
     }
 
@@ -800,7 +800,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let mut block = AudioBlockPlanar::<f32>::new(3, 4);
-        block.set_visible_size(2, 3);
+        block.set_visible(2, 3);
 
         block.channel(2);
     }
@@ -810,7 +810,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
         let mut block = AudioBlockPlanar::<f32>::new(3, 4);
-        block.set_visible_size(2, 3);
+        block.set_visible(2, 3);
 
         block.channel_mut(2);
     }

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -287,13 +287,13 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     type PlanarViewMut = Box<[S]>;
 
     #[nonblocking]
-    fn set_active_num_channels(&mut self, num_channels: u16) {
+    fn set_num_channels_visible(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
         self.num_channels = num_channels;
     }
 
     #[nonblocking]
-    fn set_active_num_frames(&mut self, num_frames: usize) {
+    fn set_num_frames_visible(&mut self, num_frames: usize) {
         assert!(num_frames <= self.num_frames_allocated);
         self.num_frames = num_frames;
     }
@@ -414,7 +414,7 @@ mod tests {
         block.channel_mut(0).copy_from_slice(&[0.0, 1.0, 2.0, 3.0]);
         block.channel_mut(1).copy_from_slice(&[4.0, 5.0, 6.0, 7.0]);
 
-        block.set_active_size(2, 3);
+        block.set_visible_size(2, 3);
 
         // single frame
         assert_eq!(block.channel(0), &[0.0, 1.0, 2.0]);
@@ -581,7 +581,7 @@ mod tests {
     #[test]
     fn test_frame_iters() {
         let mut block = AudioBlockPlanar::<f32>::new(3, 6);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
 
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames_iter();
@@ -725,8 +725,8 @@ mod tests {
             assert_eq!(block.frame_iter_mut(i).count(), 3);
         }
 
-        block.set_active_size(3, 10);
-        block.set_active_size(2, 5);
+        block.set_visible_size(3, 10);
+        block.set_visible_size(2, 5);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 5);
@@ -748,7 +748,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_channels() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_active_size(3, 10);
+        block.set_visible_size(3, 10);
     }
 
     #[test]
@@ -756,7 +756,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_frames() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_active_size(2, 11);
+        block.set_visible_size(2, 11);
     }
 
     #[test]
@@ -764,7 +764,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_active_size(1, 10);
+        block.set_visible_size(1, 10);
         let _ = block.channel_iter(1);
     }
 
@@ -773,7 +773,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         let _ = block.frame_iter(5);
     }
 
@@ -782,7 +782,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel_mut() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_active_size(1, 10);
+        block.set_visible_size(1, 10);
         let _ = block.channel_iter_mut(1);
     }
 
@@ -791,7 +791,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame_mut() {
         let mut block = AudioBlockPlanar::<f32>::new(2, 10);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         let _ = block.frame_iter_mut(5);
     }
 
@@ -800,7 +800,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let mut block = AudioBlockPlanar::<f32>::new(3, 4);
-        block.set_active_size(2, 3);
+        block.set_visible_size(2, 3);
 
         block.channel(2);
     }
@@ -810,7 +810,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
         let mut block = AudioBlockPlanar::<f32>::new(3, 4);
-        block.set_active_size(2, 3);
+        block.set_visible_size(2, 3);
 
         block.channel_mut(2);
     }

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -688,7 +688,6 @@ mod tests {
         let block = AudioBlockPlanar::<f32>::from_block(&AudioBlockInterleavedView::from_slice(
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
             2,
-            5,
         ));
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated(), 2);
@@ -729,7 +728,6 @@ mod tests {
         let block = AudioBlockPlanar::<f32>::from_block(&AudioBlockInterleavedView::from_slice(
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
             2,
-            5,
         ));
 
         assert!(block.as_interleaved_view().is_none());

--- a/src/planar/view.rs
+++ b/src/planar/view.rs
@@ -116,7 +116,7 @@ impl<'a, S: Sample, V: AsRef<[S]>> AudioBlockPlanarView<'a, S, V> {
     /// Provides direct mutable access to the underlying memory.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[V] {
         self.data
@@ -186,7 +186,7 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
-            // Limit to the active number of channels
+            // Limit to the visible number of channels
             .take(self.num_channels as usize)
             // For each channel slice, create an iterator over its samples
             .map(move |channel_data| channel_data.as_ref().iter().take(num_frames))

--- a/src/planar/view.rs
+++ b/src/planar/view.rs
@@ -42,12 +42,12 @@ impl<'a, S: Sample, V: AsRef<[S]>> AudioBlockPlanarView<'a, S, V> {
     /// Panics if the channel slices have different lengths.
     #[nonblocking]
     pub fn from_slice(data: &'a [V]) -> Self {
-        let num_frames_available = if data.is_empty() {
+        let num_frames_allocated = if data.is_empty() {
             0
         } else {
             data[0].as_ref().len()
         };
-        Self::from_slice_limited(data, data.len() as u16, num_frames_available)
+        Self::from_slice_limited(data, data.len() as u16, num_frames_allocated)
     }
 
     /// Creates a new audio block from a slice with limited visibility.

--- a/src/planar/view_mut.rs
+++ b/src/planar/view_mut.rs
@@ -280,13 +280,13 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlana
     type PlanarViewMut = V;
 
     #[nonblocking]
-    fn set_active_num_channels(&mut self, num_channels: u16) {
+    fn set_num_channels_visible(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
         self.num_channels = num_channels;
     }
 
     #[nonblocking]
-    fn set_active_num_frames(&mut self, num_frames: usize) {
+    fn set_num_frames_visible(&mut self, num_frames: usize) {
         assert!(num_frames <= self.num_frames_allocated);
         self.num_frames = num_frames;
     }
@@ -701,7 +701,7 @@ mod tests {
         let mut ch3 = vec![0.0; 10];
         let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice(), ch3.as_mut_slice()];
         let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
 
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames_iter();

--- a/src/planar/view_mut.rs
+++ b/src/planar/view_mut.rs
@@ -44,12 +44,12 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockPlanarViewMut<'a, S, V
     /// Panics if the channel slices have different lengths.
     #[nonblocking]
     pub fn from_slice(data: &'a mut [V]) -> Self {
-        let num_frames_available = if data.is_empty() {
+        let num_frames_allocated = if data.is_empty() {
             0
         } else {
             data[0].as_ref().len()
         };
-        Self::from_slice_limited(data, data.len() as u16, num_frames_available)
+        Self::from_slice_limited(data, data.len() as u16, num_frames_allocated)
     }
 
     /// Creates a new audio block from a mutable slice with limited visibility.
@@ -72,23 +72,23 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockPlanarViewMut<'a, S, V
         num_channels_visible: u16,
         num_frames_visible: usize,
     ) -> Self {
-        let num_channels_available = data.len();
-        let num_frames_available = if num_channels_available == 0 {
+        let num_channels_allocated = data.len();
+        let num_frames_allocated = if num_channels_allocated == 0 {
             0
         } else {
             data[0].as_ref().len()
         };
-        assert!(num_channels_visible <= num_channels_available as u16);
-        assert!(num_frames_visible <= num_frames_available);
+        assert!(num_channels_visible <= num_channels_allocated as u16);
+        assert!(num_frames_visible <= num_frames_allocated);
         data.iter()
-            .for_each(|v| assert_eq!(v.as_ref().len(), num_frames_available));
+            .for_each(|v| assert_eq!(v.as_ref().len(), num_frames_allocated));
 
         Self {
             data,
             num_channels: num_channels_visible,
             num_frames: num_frames_visible,
-            num_channels_allocated: num_channels_available as u16,
-            num_frames_allocated: num_frames_available,
+            num_channels_allocated: num_channels_allocated as u16,
+            num_frames_allocated: num_frames_allocated,
             _phantom: PhantomData,
         }
     }

--- a/src/planar/view_mut.rs
+++ b/src/planar/view_mut.rs
@@ -88,7 +88,7 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockPlanarViewMut<'a, S, V
             num_channels: num_channels_visible,
             num_frames: num_frames_visible,
             num_channels_allocated: num_channels_allocated as u16,
-            num_frames_allocated: num_frames_allocated,
+            num_frames_allocated,
             _phantom: PhantomData,
         }
     }

--- a/src/planar/view_mut.rs
+++ b/src/planar/view_mut.rs
@@ -140,7 +140,7 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockPlanarViewMut<'a, S, V
     /// Provides direct access to the underlying memory.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[V] {
         self.data
@@ -149,7 +149,7 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockPlanarViewMut<'a, S, V
     /// Provides direct access to the underlying memory.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data_mut(&mut self) -> &mut [V] {
         self.data
@@ -224,7 +224,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
-            // Limit to the active number of channels
+            // Limit to the visible number of channels
             .take(self.num_channels as usize)
             // For each channel slice, create an iterator over its samples
             .map(move |channel_data| channel_data.as_ref().iter().take(num_frames))
@@ -701,7 +701,7 @@ mod tests {
         let mut ch3 = vec![0.0; 10];
         let mut data = vec![ch1.as_mut_slice(), ch2.as_mut_slice(), ch3.as_mut_slice()];
         let mut block = AudioBlockPlanarViewMut::from_slice(&mut data);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
 
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames_iter();

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -152,7 +152,7 @@ impl<S: Sample> AudioBlockSequential<S> {
     /// Provides direct access to the underlying memory as a sequential slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[S] {
         &self.data
@@ -161,7 +161,7 @@ impl<S: Sample> AudioBlockSequential<S> {
     /// Provides direct mutable access to the underlying memory as a sequential slice.
     ///
     /// This function gives mutable access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data_mut(&mut self) -> &mut [S] {
         &mut self.data
@@ -240,7 +240,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
 
     #[nonblocking]
     fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
-        let num_frames = self.num_frames; // Active frames per channel
+        let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
         self.data
@@ -436,7 +436,7 @@ mod tests {
         let mut block = AudioBlockSequential::<f32>::new(3, 4);
         block.channel_mut(0).copy_from_slice(&[0.0, 1.0, 2.0, 3.0]);
         block.channel_mut(1).copy_from_slice(&[4.0, 5.0, 6.0, 7.0]);
-        block.set_visible_size(2, 3);
+        block.set_visible(2, 3);
 
         // single frame
         assert_eq!(block.channel(0), &[0.0, 1.0, 2.0]);
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn test_frame_iters() {
         let mut block = AudioBlockSequential::<f32>::new(3, 6);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
 
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames_iter();
@@ -734,7 +734,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let mut block = AudioBlockSequential::<f32>::new(3, 6);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         block.channel(2);
     }
 
@@ -743,7 +743,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
         let mut block = AudioBlockSequential::<f32>::new(3, 6);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         block.channel_mut(2);
     }
 
@@ -764,8 +764,8 @@ mod tests {
             assert_eq!(block.frame_iter_mut(i).count(), 3);
         }
 
-        block.set_visible_size(3, 10);
-        block.set_visible_size(2, 5);
+        block.set_visible(3, 10);
+        block.set_visible(2, 5);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 5);
@@ -787,7 +787,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_channels() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_visible_size(3, 10);
+        block.set_visible(3, 10);
     }
 
     #[test]
@@ -795,7 +795,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_frames() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_visible_size(2, 11);
+        block.set_visible(2, 11);
     }
 
     #[test]
@@ -803,7 +803,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_visible_size(1, 10);
+        block.set_visible(1, 10);
         let _ = block.channel_iter(1);
     }
 
@@ -812,7 +812,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
         let _ = block.frame_iter(5);
     }
 
@@ -821,7 +821,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel_mut() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_visible_size(1, 10);
+        block.set_visible(1, 10);
         let _ = block.channel_iter_mut(1);
     }
 }

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -80,13 +80,18 @@ impl<S: Sample> AudioBlockSequential<S> {
     /// # Parameters
     /// * `data` - The slice containing sequential audio samples
     /// * `num_channels` - Number of audio channels in the data
-    /// * `num_frames` - Number of audio frames in the data
     ///
     /// # Panics
-    /// Panics if the length of `data` doesn't equal `num_channels * num_frames`.
+    /// Panics if the length of `data` is not evenly divisible by `num_channels`.
     #[blocking]
-    pub fn from_slice(data: &[S], num_channels: u16, num_frames: usize) -> Self {
-        assert_eq!(data.len(), num_channels as usize * num_frames);
+    pub fn from_slice(data: &[S], num_channels: u16) -> Self {
+        assert!(
+            num_channels > 0 && data.len() % num_channels as usize == 0,
+            "data length {} must be divisible by num_channels {}",
+            data.len(),
+            num_channels
+        );
+        let num_frames = data.len() / num_channels as usize;
         Self {
             data: data.to_vec().into_boxed_slice(),
             num_channels,
@@ -707,7 +712,6 @@ mod tests {
             AudioBlockSequential::<f32>::from_block(&AudioBlockInterleavedView::from_slice(
                 &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
                 2,
-                5,
             ));
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated(), 2);
@@ -749,7 +753,6 @@ mod tests {
             AudioBlockSequential::<f32>::from_block(&AudioBlockInterleavedView::from_slice(
                 &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
                 2,
-                5,
             ));
         assert!(block.as_interleaved_view().is_none());
         assert!(block.as_planar_view().is_none());

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -43,7 +43,7 @@ pub struct AudioBlockSequential<S: Sample> {
     num_frames_allocated: usize,
 }
 
-impl<S: Sample> AudioBlockSequential<S> {
+impl<S: Sample + Default> AudioBlockSequential<S> {
     /// Creates a new audio block with the specified dimensions.
     ///
     /// Allocates memory with exactly the specified number of channels and
@@ -65,14 +65,15 @@ impl<S: Sample> AudioBlockSequential<S> {
             .checked_mul(num_frames)
             .expect("Multiplication overflow: num_channels * num_frames is too large");
         Self {
-            data: vec![S::zero(); total_samples].into_boxed_slice(),
+            data: vec![S::default(); total_samples].into_boxed_slice(),
             num_channels,
             num_frames,
             num_channels_allocated: num_channels,
             num_frames_allocated: num_frames,
         }
     }
-
+}
+impl<S: Sample> AudioBlockSequential<S> {
     /// Creates a new audio block by copying data from another [`AudioBlock`].
     ///
     /// Converts any [`AudioBlock`] implementation to a sequential format by iterating

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -306,13 +306,13 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     type PlanarViewMut = [S; 0];
 
     #[nonblocking]
-    fn set_active_num_channels(&mut self, num_channels: u16) {
+    fn set_num_channels_visible(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
         self.num_channels = num_channels;
     }
 
     #[nonblocking]
-    fn set_active_num_frames(&mut self, num_frames: usize) {
+    fn set_num_frames_visible(&mut self, num_frames: usize) {
         assert!(num_frames <= self.num_frames_allocated);
         self.num_frames = num_frames;
     }
@@ -436,7 +436,7 @@ mod tests {
         let mut block = AudioBlockSequential::<f32>::new(3, 4);
         block.channel_mut(0).copy_from_slice(&[0.0, 1.0, 2.0, 3.0]);
         block.channel_mut(1).copy_from_slice(&[4.0, 5.0, 6.0, 7.0]);
-        block.set_active_size(2, 3);
+        block.set_visible_size(2, 3);
 
         // single frame
         assert_eq!(block.channel(0), &[0.0, 1.0, 2.0]);
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn test_frame_iters() {
         let mut block = AudioBlockSequential::<f32>::new(3, 6);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
 
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames_iter();
@@ -734,7 +734,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds() {
         let mut block = AudioBlockSequential::<f32>::new(3, 6);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         block.channel(2);
     }
 
@@ -743,7 +743,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_slice_out_of_bounds_mut() {
         let mut block = AudioBlockSequential::<f32>::new(3, 6);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         block.channel_mut(2);
     }
 
@@ -764,8 +764,8 @@ mod tests {
             assert_eq!(block.frame_iter_mut(i).count(), 3);
         }
 
-        block.set_active_size(3, 10);
-        block.set_active_size(2, 5);
+        block.set_visible_size(3, 10);
+        block.set_visible_size(2, 5);
 
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_frames(), 5);
@@ -787,7 +787,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_channels() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_active_size(3, 10);
+        block.set_visible_size(3, 10);
     }
 
     #[test]
@@ -795,7 +795,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_resize_frames() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_active_size(2, 11);
+        block.set_visible_size(2, 11);
     }
 
     #[test]
@@ -803,7 +803,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_active_size(1, 10);
+        block.set_visible_size(1, 10);
         let _ = block.channel_iter(1);
     }
 
@@ -812,7 +812,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_frame() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
         let _ = block.frame_iter(5);
     }
 
@@ -821,7 +821,7 @@ mod tests {
     #[no_sanitize_realtime]
     fn test_wrong_channel_mut() {
         let mut block = AudioBlockSequential::<f32>::new(2, 10);
-        block.set_active_size(1, 10);
+        block.set_visible_size(1, 10);
         let _ = block.channel_iter_mut(1);
     }
 }

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -149,7 +149,7 @@ impl<S: Sample> AudioBlockSequential<S> {
             .map(|frame| &mut frame[..self.num_frames])
     }
 
-    /// Provides direct access to the underlying memory as an interleaved slice.
+    /// Provides direct access to the underlying memory as a sequential slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
     /// beyond the active range.
@@ -158,7 +158,7 @@ impl<S: Sample> AudioBlockSequential<S> {
         &self.data
     }
 
-    /// Provides direct mutable access to the underlying memory as an interleaved slice.
+    /// Provides direct mutable access to the underlying memory as a sequential slice.
     ///
     /// This function gives mutable access to all allocated data, including any reserved capacity
     /// beyond the active range.

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -73,7 +73,68 @@ impl<S: Sample + Default> AudioBlockSequential<S> {
         }
     }
 }
+
 impl<S: Sample> AudioBlockSequential<S> {
+    /// Creates a new sequential audio block by copying the data from a slice of sequential audio data.
+    ///
+    /// # Parameters
+    /// * `data` - The slice containing sequential audio samples
+    /// * `num_channels` - Number of audio channels in the data
+    /// * `num_frames` - Number of audio frames in the data
+    ///
+    /// # Panics
+    /// Panics if the length of `data` doesn't equal `num_channels * num_frames`.
+    #[blocking]
+    pub fn from_slice(data: &[S], num_channels: u16, num_frames: usize) -> Self {
+        assert_eq!(data.len(), num_channels as usize * num_frames);
+        Self {
+            data: data.to_vec().into_boxed_slice(),
+            num_channels,
+            num_frames,
+            num_channels_allocated: num_channels,
+            num_frames_allocated: num_frames,
+        }
+    }
+
+    /// Creates a new sequential audio block by copying the data from a slice of sequential audio data with limited visibility.
+    ///
+    /// This function allows creating a block that exposes only a subset of the allocated channels
+    /// and frames, which is useful for working with a logical section of a larger buffer.
+    ///
+    /// # Parameters
+    /// * `data` - The slice containing sequential audio samples
+    /// * `num_channels_visible` - Number of audio channels to expose
+    /// * `num_frames_visible` - Number of audio frames to expose
+    /// * `num_channels_allocated` - Total number of channels allocated in the data buffer
+    /// * `num_frames_allocated` - Total number of frames allocated in the data buffer
+    ///
+    /// # Panics
+    /// * Panics if the length of `data` doesn't equal `num_channels_allocated * num_frames_allocated`
+    /// * Panics if `num_channels_visible` exceeds `num_channels_allocated`
+    /// * Panics if `num_frames_visible` exceeds `num_frames_allocated`
+    #[blocking]
+    pub fn from_slice_limited(
+        data: &[S],
+        num_channels_visible: u16,
+        num_frames_visible: usize,
+        num_channels_allocated: u16,
+        num_frames_allocated: usize,
+    ) -> Self {
+        assert_eq!(
+            data.len(),
+            num_channels_allocated as usize * num_frames_allocated
+        );
+        assert!(num_channels_visible <= num_channels_allocated);
+        assert!(num_frames_visible <= num_frames_allocated);
+        Self {
+            data: data.to_vec().into_boxed_slice(),
+            num_channels: num_channels_visible,
+            num_frames: num_frames_visible,
+            num_channels_allocated,
+            num_frames_allocated,
+        }
+    }
+
     /// Creates a new audio block by copying data from another [`AudioBlock`].
     ///
     /// Converts any [`AudioBlock`] implementation to a sequential format by iterating

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -518,7 +518,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw() {
+    fn test_from_ptr() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
         let block = unsafe { AudioBlockSequentialView::<f32>::from_ptr(data.as_mut_ptr(), 2, 5) };
         assert_eq!(block.num_channels(), 2);
@@ -556,7 +556,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw_limited() {
+    fn test_from_ptr_limited() {
         let data = [1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 5.0, 6.0, 0.0, 0.0, 0.0, 0.0];
 
         let block =

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -168,7 +168,7 @@ impl<'a, S: Sample> AudioBlockSequentialView<'a, S> {
     /// Provides direct access to the underlying memory as a sequential slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[S] {
         &self.data
@@ -236,7 +236,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
 
     #[nonblocking]
     fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
-        let num_frames = self.num_frames; // Active frames per channel
+        let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
         self.data

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -165,7 +165,7 @@ impl<'a, S: Sample> AudioBlockSequentialView<'a, S> {
             .map(|frame| &frame[..self.num_frames])
     }
 
-    /// Provides direct access to the underlying memory as an interleaved slice.
+    /// Provides direct access to the underlying memory as a sequential slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
     /// beyond the active range.

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -18,7 +18,7 @@ use crate::{AudioBlock, Sample, iter::StridedSampleIter};
 ///
 /// let data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
 ///
-/// let block = AudioBlockSequentialView::from_slice(&data, 2, 3);
+/// let block = AudioBlockSequentialView::from_slice(&data, 2);
 ///
 /// assert_eq!(block.channel(0), &[0.0, 0.0, 0.0]);
 /// assert_eq!(block.channel(1), &[1.0, 1.0, 1.0]);
@@ -37,13 +37,18 @@ impl<'a, S: Sample> AudioBlockSequentialView<'a, S> {
     /// # Parameters
     /// * `data` - The slice containing sequential audio samples
     /// * `num_channels` - Number of audio channels in the data
-    /// * `num_frames` - Number of audio frames in the data
     ///
     /// # Panics
-    /// Panics if the length of `data` doesn't equal `num_channels * num_frames`.
+    /// Panics if the length of `data` is not evenly divisible by `num_channels`.
     #[nonblocking]
-    pub fn from_slice(data: &'a [S], num_channels: u16, num_frames: usize) -> Self {
-        assert_eq!(data.len(), num_channels as usize * num_frames);
+    pub fn from_slice(data: &'a [S], num_channels: u16) -> Self {
+        assert!(
+            num_channels > 0 && data.len() % num_channels as usize == 0,
+            "data length {} must be divisible by num_channels {}",
+            data.len(),
+            num_channels
+        );
+        let num_frames = data.len() / num_channels as usize;
         Self {
             data,
             num_channels,
@@ -81,6 +86,8 @@ impl<'a, S: Sample> AudioBlockSequentialView<'a, S> {
             data.len(),
             num_channels_allocated as usize * num_frames_allocated
         );
+        assert!(num_channels_visible <= num_channels_allocated);
+        assert!(num_frames_visible <= num_frames_allocated);
         Self {
             data,
             num_channels: num_channels_visible,
@@ -369,7 +376,7 @@ mod tests {
     #[test]
     fn test_samples() {
         let data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2, 5);
+        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2);
 
         for ch in 0..block.num_channels() {
             for f in 0..block.num_frames() {
@@ -384,7 +391,7 @@ mod tests {
     #[test]
     fn test_channel_iter() {
         let data = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2, 5);
+        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2);
 
         let channel = block.channel_iter(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 1.0, 2.0, 3.0, 4.0]);
@@ -395,7 +402,7 @@ mod tests {
     #[test]
     fn test_channel_iters() {
         let data = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2, 5);
+        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2);
 
         let mut channels_iter = block.channels_iter();
         let channel = channels_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -409,7 +416,7 @@ mod tests {
     #[test]
     fn test_frame_iter() {
         let data = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2, 5);
+        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2);
 
         let channel = block.frame_iter(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 5.0]);
@@ -426,7 +433,7 @@ mod tests {
     #[test]
     fn test_frame_iters() {
         let data = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2, 5);
+        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2);
 
         let mut frames_iter = block.frames_iter();
         let channel = frames_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -445,7 +452,7 @@ mod tests {
     #[test]
     fn test_from_slice() {
         let data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2, 5);
+        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2);
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated, 2);
         assert_eq!(block.num_frames(), 5);
@@ -483,7 +490,7 @@ mod tests {
     #[test]
     fn test_view() {
         let data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2, 5);
+        let block = AudioBlockSequentialView::<f32>::from_slice(&data, 2);
         assert!(block.as_interleaved_view().is_none());
         assert!(block.as_planar_view().is_none());
         assert!(block.as_sequential_view().is_some());

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -95,7 +95,7 @@ impl<'a, S: Sample> AudioBlockSequentialView<'a, S> {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr` points to valid memory containing at least `num_channels_available * num_frames_available` elements
+    /// - `ptr` points to valid memory containing at least `num_channels_allocated * num_frames_allocated` elements
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]
@@ -114,7 +114,7 @@ impl<'a, S: Sample> AudioBlockSequentialView<'a, S> {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr` points to valid memory containing at least `num_channels_available * num_frames_available` elements
+    /// - `ptr` points to valid memory containing at least `num_channels_allocated * num_frames_allocated` elements
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -22,7 +22,7 @@ use crate::{
 ///
 /// let mut data = vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
 ///
-/// let block = AudioBlockSequentialViewMut::from_slice(&mut data, 2, 3);
+/// let block = AudioBlockSequentialViewMut::from_slice(&mut data, 2);
 ///
 /// assert_eq!(block.channel(0), &[0.0, 0.0, 0.0]);
 /// assert_eq!(block.channel(1), &[1.0, 1.0, 1.0]);
@@ -41,13 +41,18 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
     /// # Parameters
     /// * `data` - The mutable slice containing sequential audio samples
     /// * `num_channels` - Number of audio channels in the data
-    /// * `num_frames` - Number of audio frames in the data
     ///
     /// # Panics
-    /// Panics if the length of `data` doesn't equal `num_channels * num_frames`.
+    /// Panics if the length of `data` is not evenly divisible by `num_channels`.
     #[nonblocking]
-    pub fn from_slice(data: &'a mut [S], num_channels: u16, num_frames: usize) -> Self {
-        assert_eq!(data.len(), num_channels as usize * num_frames);
+    pub fn from_slice(data: &'a mut [S], num_channels: u16) -> Self {
+        assert!(
+            num_channels > 0 && data.len() % num_channels as usize == 0,
+            "data length {} must be divisible by num_channels {}",
+            data.len(),
+            num_channels
+        );
+        let num_frames = data.len() / num_channels as usize;
         Self {
             data,
             num_channels,
@@ -537,7 +542,7 @@ mod tests {
     #[test]
     fn test_samples() {
         let mut data = vec![0.0; 10];
-        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2);
 
         let num_frames = block.num_frames();
         for ch in 0..block.num_channels() {
@@ -578,7 +583,7 @@ mod tests {
     #[test]
     fn test_channel_iter() {
         let mut data = vec![0.0; 10];
-        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2);
 
         let channel = block.channel_iter(0).copied().collect::<Vec<_>>();
         assert_eq!(channel, vec![0.0, 0.0, 0.0, 0.0, 0.0]);
@@ -603,7 +608,7 @@ mod tests {
     #[test]
     fn test_channel_iters() {
         let mut data = vec![0.0; 10];
-        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2);
 
         let mut channels_iter = block.channels_iter();
         let channel = channels_iter.next().unwrap().copied().collect::<Vec<_>>();
@@ -639,7 +644,7 @@ mod tests {
     #[test]
     fn test_frame_iter() {
         let mut data = vec![0.0; 12];
-        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2);
         block.set_visible(2, 5);
 
         for i in 0..block.num_frames() {
@@ -670,7 +675,7 @@ mod tests {
     #[test]
     fn test_frame_iters() {
         let mut data = vec![0.0; 12];
-        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2);
         block.set_visible(2, 5);
 
         let num_frames = block.num_frames;
@@ -711,7 +716,7 @@ mod tests {
     #[test]
     fn test_from_slice() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2);
         assert_eq!(block.num_channels(), 2);
         assert_eq!(block.num_channels_allocated, 2);
         assert_eq!(block.num_frames(), 5);
@@ -749,7 +754,7 @@ mod tests {
     #[test]
     fn test_view() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-        let block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2);
         assert!(block.as_interleaved_view().is_none());
         assert!(block.as_planar_view().is_none());
         assert!(block.as_sequential_view().is_some());
@@ -767,7 +772,7 @@ mod tests {
     #[test]
     fn test_view_mut() {
         let mut data = vec![0.0; 10];
-        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 5);
+        let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2);
         assert!(block.as_interleaved_view().is_none());
         assert!(block.as_planar_view().is_none());
         assert!(block.as_sequential_view().is_some());

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -354,13 +354,13 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     type PlanarViewMut = [S; 0];
 
     #[nonblocking]
-    fn set_active_num_channels(&mut self, num_channels: u16) {
+    fn set_num_channels_visible(&mut self, num_channels: u16) {
         assert!(num_channels <= self.num_channels_allocated);
         self.num_channels = num_channels;
     }
 
     #[nonblocking]
-    fn set_active_num_frames(&mut self, num_frames: usize) {
+    fn set_num_frames_visible(&mut self, num_frames: usize) {
         assert!(num_frames <= self.num_frames_allocated);
         self.num_frames = num_frames;
     }
@@ -640,7 +640,7 @@ mod tests {
     fn test_frame_iter() {
         let mut data = vec![0.0; 12];
         let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
 
         for i in 0..block.num_frames() {
             let frame = block.frame_iter(i).copied().collect::<Vec<_>>();
@@ -671,7 +671,7 @@ mod tests {
     fn test_frame_iters() {
         let mut data = vec![0.0; 12];
         let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
-        block.set_active_size(2, 5);
+        block.set_visible_size(2, 5);
 
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames_iter();

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -78,21 +78,21 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
         data: &'a mut [S],
         num_channels_visible: u16,
         num_frames_visible: usize,
-        num_channels_available: u16,
-        num_frames_available: usize,
+        num_channels_allocated: u16,
+        num_frames_allocated: usize,
     ) -> Self {
-        assert!(num_channels_visible <= num_channels_available);
-        assert!(num_frames_visible <= num_frames_available);
+        assert!(num_channels_visible <= num_channels_allocated);
+        assert!(num_frames_visible <= num_frames_allocated);
         assert_eq!(
             data.len(),
-            num_channels_available as usize * num_frames_available
+            num_channels_allocated as usize * num_frames_allocated
         );
         Self {
             data,
             num_channels: num_channels_visible,
             num_frames: num_frames_visible,
-            num_channels_allocated: num_channels_available,
-            num_frames_allocated: num_frames_available,
+            num_channels_allocated,
+            num_frames_allocated,
         }
     }
 
@@ -101,7 +101,7 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr` points to valid memory containing at least `num_channels_available * num_frames_available` elements
+    /// - `ptr` points to valid memory containing at least `num_channels_allocated * num_frames_allocated` elements
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]
@@ -122,7 +122,7 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
     /// # Safety
     ///
     /// The caller must ensure that:
-    /// - `ptr` points to valid memory containing at least `num_channels_available * num_frames_available` elements
+    /// - `ptr` points to valid memory containing at least `num_channels_allocated * num_frames_allocated` elements
     /// - The memory referenced by `ptr` must be valid for the lifetime of the returned `SequentialView`
     /// - The memory must not be mutated through other pointers while this view exists
     #[nonblocking]

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -200,7 +200,7 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
     /// Provides direct access to the underlying memory as a sequential slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data(&self) -> &[S] {
         &self.data
@@ -209,7 +209,7 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
     /// Provides direct mutable access to the underlying memory as a sequential slice.
     ///
     /// This function gives mutable access to all allocated data, including any reserved capacity
-    /// beyond the active range.
+    /// beyond the visible range.
     #[nonblocking]
     pub fn raw_data_mut(&mut self) -> &mut [S] {
         &mut self.data
@@ -288,7 +288,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
 
     #[nonblocking]
     fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
-        let num_frames = self.num_frames; // Active frames per channel
+        let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
         self.data
@@ -640,7 +640,7 @@ mod tests {
     fn test_frame_iter() {
         let mut data = vec![0.0; 12];
         let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
 
         for i in 0..block.num_frames() {
             let frame = block.frame_iter(i).copied().collect::<Vec<_>>();
@@ -671,7 +671,7 @@ mod tests {
     fn test_frame_iters() {
         let mut data = vec![0.0; 12];
         let mut block = AudioBlockSequentialViewMut::<f32>::from_slice(&mut data, 2, 6);
-        block.set_visible_size(2, 5);
+        block.set_visible(2, 5);
 
         let num_frames = block.num_frames;
         let mut frames_iter = block.frames_iter();

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -813,7 +813,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw() {
+    fn test_from_ptr() {
         let mut data = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
         let block =
             unsafe { AudioBlockSequentialViewMut::<f32>::from_ptr(data.as_mut_ptr(), 2, 5) };
@@ -826,7 +826,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_raw_limited() {
+    fn test_from_ptr_limited() {
         let mut data = [1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 5.0, 6.0, 0.0, 0.0, 0.0, 0.0];
 
         let mut block =

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -197,7 +197,7 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
             .map(|frame| &mut frame[..self.num_frames])
     }
 
-    /// Provides direct access to the underlying memory as an interleaved slice.
+    /// Provides direct access to the underlying memory as a sequential slice.
     ///
     /// This function gives access to all allocated data, including any reserved capacity
     /// beyond the active range.
@@ -206,7 +206,7 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
         &self.data
     }
 
-    /// Provides direct mutable access to the underlying memory as an interleaved slice.
+    /// Provides direct mutable access to the underlying memory as a sequential slice.
     ///
     /// This function gives mutable access to all allocated data, including any reserved capacity
     /// beyond the active range.


### PR DESCRIPTION
## Breaking Changes

### API Renames (Terminology)
- **`set_active_size` -> `set_visible`**: Renamed to clarify intent
- **`set_active_num_channels` -> `set_num_channels_visible`**: Consistent naming
- **`set_active_num_frames` -> `set_num_frames_visible`**: Consistent naming
- **`from_raw` -> `from_ptr`**: Renamed for views created from raw pointers
- **`from_raw_limited` -> `from_ptr_limited`**: Consistent naming

### Trait Changes
- **`Sample` trait no longer requires `num::Zero`**: The `num` dependency has been removed entirely. Sample types now only need `Copy + 'static`.
- **`AudioBlockOps` split into two traits**:
  - `AudioBlockOps<S>`: Read-only operations (implemented for `AudioBlock`)
  - `AudioBlockOpsMut<S>`: Mutable operations (implemented for `AudioBlockMut`)
- **`clear()` now requires `S: Default`**: The method has a `where S: Default` bound since `Sample` no longer requires `num::Zero`

### Copy Operation Behavior Changes
- **`copy_from_block` now clamps to smaller dimensions**: Previously required exact size match. Now safely resizes destination to `min(src, dst)` channels and frames.
- **`copy_from_block_resize` -> `copy_from_block_exact`**: Use this if you need the old strict behavior that panics on size mismatch.

### View Construction Changes
- **`from_slice` no longer requires `num_frames` parameter** for interleaved and sequential views: Frame count is now derived from `data.len() / num_channels`.

## New Features

### Mono Audio Block Type
New dedicated single-channel audio block with a streamlined API:
- `AudioBlockMono<S>` - Owned mono block
- `AudioBlockMonoView<'a, S>` - Immutable view
- `AudioBlockMonoViewMut<'a, S>` - Mutable view

Mono blocks provide direct sample access without channel indexing:
```rust
let mut block = AudioBlockMono::new(512);
block.samples_mut()[0] = 1.0;
let sample = block.sample(0);
```

### Mono Conversion Operations
- **`mix_to_mono(&self, dest)`**: Mix all channels to mono by averaging (on `AudioBlockOps`)
- **`copy_mono_to_all_channels(&mut self, mono)`**: Copy mono block to all channels (on `AudioBlockOpsMut`)

### `from_slice` for Owned Blocks
Owned blocks now support construction from slices:
- `AudioBlockInterleaved::from_slice(&data, num_channels)`
- `AudioBlockInterleaved::from_slice_limited(&data, ch_visible, frames_visible, ch_alloc, frames_alloc)`
- `AudioBlockSequential::from_slice(&data, num_channels)`
- `AudioBlockSequential::from_slice_limited(...)`
- `AudioBlockPlanar::from_slice(&channel_slices)`
- `AudioBlockMono::from_slice(&samples)`
- `AudioBlockMono::from_slice_limited(&samples, num_frames_visible)`

## Dependency Changes

- **Removed `num` dependency**: No longer required. The library now has zero required dependencies (only `rtsan-standalone` which is compile-time only).
- **Updated `criterion` to 0.8.1**: Dev dependency update for benchmarks.

## Documentation

- Clarified difference between `Sequential` and `Planar` layouts in `BlockLayout` enum documentation
- Updated README with mono block examples and clearer API documentation
- Fixed comments referencing old terminology
