### PR TITLE
Use ExactSizeIterator for iterator-returning methods

### DIFF
--- a/src/interleaved/owned.rs
+++ b/src/interleaved/owned.rs
@@ -200,7 +200,7 @@ impl<S: Sample> AudioBlockInterleaved<S> {
     ///
     /// Each frame is represented as a slice of samples.
     #[nonblocking]
-    pub fn frames(&self) -> impl Iterator<Item = &[S]> {
+    pub fn frames(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .chunks(self.num_channels_allocated as usize)
             .take(self.num_frames)
@@ -211,7 +211,7 @@ impl<S: Sample> AudioBlockInterleaved<S> {
     ///
     /// Each frame is represented as a mutable slice of samples.
     #[nonblocking]
-    pub fn frames_mut(&mut self) -> impl Iterator<Item = &mut [S]> {
+    pub fn frames_mut(&mut self) -> impl ExactSizeIterator<Item = &mut [S]> {
         let num_channels = self.num_channels as usize;
         self.data
             .chunks_mut(self.num_channels_allocated as usize)
@@ -300,7 +300,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         self.data
             .iter()
@@ -310,7 +310,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -348,7 +351,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -357,7 +360,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data
@@ -403,7 +409,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         self.data
             .iter_mut()
@@ -415,7 +424,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -442,7 +452,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(frame < self.num_frames);
         self.data
             .iter_mut()
@@ -451,7 +461,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S> + ExactSizeIterator> {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data

--- a/src/interleaved/owned.rs
+++ b/src/interleaved/owned.rs
@@ -310,10 +310,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -360,10 +357,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data
@@ -409,10 +403,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S> {
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         self.data
             .iter_mut()
@@ -424,8 +415,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -463,8 +453,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleaved<S> {
     #[nonblocking]
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S> + ExactSizeIterator> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S> + ExactSizeIterator>
+    {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data

--- a/src/interleaved/view.rs
+++ b/src/interleaved/view.rs
@@ -244,10 +244,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedView<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -288,10 +285,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedView<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data

--- a/src/interleaved/view.rs
+++ b/src/interleaved/view.rs
@@ -166,7 +166,7 @@ impl<'a, S: Sample> AudioBlockInterleavedView<'a, S> {
     ///
     /// Each frame is represented as a slice of samples.
     #[nonblocking]
-    pub fn frames(&self) -> impl Iterator<Item = &[S]> {
+    pub fn frames(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .chunks(self.num_channels_allocated as usize)
             .take(self.num_frames)
@@ -234,7 +234,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedView<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         self.data
             .iter()
@@ -244,7 +244,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedView<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -276,7 +279,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedView<'_, S> {
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -285,7 +288,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedView<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data

--- a/src/interleaved/view_mut.rs
+++ b/src/interleaved/view_mut.rs
@@ -185,7 +185,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
     ///
     /// Each frame is represented as a slice of samples.
     #[nonblocking]
-    pub fn frames(&self) -> impl Iterator<Item = &[S]> {
+    pub fn frames(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .chunks(self.num_channels_allocated as usize)
             .take(self.num_frames)
@@ -196,7 +196,7 @@ impl<'a, S: Sample> AudioBlockInterleavedViewMut<'a, S> {
     ///
     /// Each frame is represented as a mutable slice of samples.
     #[nonblocking]
-    pub fn frames_mut(&mut self) -> impl Iterator<Item = &mut [S]> {
+    pub fn frames_mut(&mut self) -> impl ExactSizeIterator<Item = &mut [S]> {
         let num_channels = self.num_channels as usize;
         self.data
             .chunks_mut(self.num_channels_allocated as usize)
@@ -285,7 +285,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         self.data
             .iter()
@@ -295,7 +295,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -327,7 +330,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -336,7 +339,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data
@@ -382,7 +388,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         self.data
             .iter_mut()
@@ -394,7 +403,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -423,7 +433,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(frame < self.num_frames);
         self.data
             .iter_mut()
@@ -432,7 +442,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data

--- a/src/interleaved/view_mut.rs
+++ b/src/interleaved/view_mut.rs
@@ -295,10 +295,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -339,10 +336,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data
@@ -388,10 +382,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S> {
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         self.data
             .iter_mut()
@@ -403,8 +394,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_channels_allocated as usize;
@@ -444,8 +434,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockInterleavedViewMut<'_, S> {
     #[nonblocking]
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_channels_allocated = self.num_channels_allocated as usize;
         self.data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,20 +162,24 @@ pub trait AudioBlock<S: Sample> {
     /// # Panics
     ///
     /// Panics if channel index is out of bounds.
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S>;
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S>;
 
     /// Returns an iterator that yields an iterator for each channel.
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_;
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>;
 
     /// Returns an iterator over all samples in the specified frame (across all channels).
     ///
     /// # Panics
     ///
     /// Panics if frame index is out of bounds.
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S>;
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S>;
 
     /// Returns an iterator that yields an iterator for each frame.
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_;
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>;
 
     /// Creates a non-owning view of this audio block.
     ///
@@ -290,21 +294,29 @@ pub trait AudioBlockMut<S: Sample>: AudioBlock<S> {
     /// # Panics
     ///
     /// Panics if channel index is out of bounds.
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S>;
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S>;
 
     /// Returns a mutable iterator that yields mutable iterators for each channel.
-    fn channels_iter_mut(&mut self)
-    -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_;
+    fn channels_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>>;
 
     /// Returns a mutable iterator over all samples in the specified frame (across all channels).
     ///
     /// # Panics
     ///
     /// Panics if frame index is out of bounds.
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S>;
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S>;
 
     /// Returns a mutable iterator that yields mutable iterators for each frame.
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_;
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>>;
 
     /// Creates a non-owning mutable view of this audio block.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,9 +165,7 @@ pub trait AudioBlock<S: Sample> {
     fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S>;
 
     /// Returns an iterator that yields an iterator for each channel.
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>;
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>>;
 
     /// Returns an iterator over all samples in the specified frame (across all channels).
     ///
@@ -177,9 +175,7 @@ pub trait AudioBlock<S: Sample> {
     fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S>;
 
     /// Returns an iterator that yields an iterator for each frame.
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>;
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>>;
 
     /// Creates a non-owning view of this audio block.
     ///
@@ -294,16 +290,12 @@ pub trait AudioBlockMut<S: Sample>: AudioBlock<S> {
     /// # Panics
     ///
     /// Panics if channel index is out of bounds.
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S>;
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S>;
 
     /// Returns a mutable iterator that yields mutable iterators for each channel.
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>>;
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>>;
 
     /// Returns a mutable iterator over all samples in the specified frame (across all channels).
     ///
@@ -315,8 +307,7 @@ pub trait AudioBlockMut<S: Sample>: AudioBlock<S> {
     /// Returns a mutable iterator that yields mutable iterators for each frame.
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>>;
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>>;
 
     /// Creates a non-owning mutable view of this audio block.
     ///

--- a/src/mono/owned.rs
+++ b/src/mono/owned.rs
@@ -268,10 +268,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMono<S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         core::iter::once(self.samples().iter())
     }
 
@@ -282,10 +279,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMono<S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         self.data.iter().take(self.num_frames).map(core::iter::once)
     }
 
@@ -329,10 +323,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMono<S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S> {
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S> {
         assert_eq!(channel, 0, "AudioBlockMono only has channel 0");
         self.samples_mut().iter_mut()
     }
@@ -340,8 +331,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMono<S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         core::iter::once(self.samples_mut().iter_mut())
     }
 
@@ -356,8 +346,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMono<S> {
     #[nonblocking]
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         self.data.iter_mut().take(num_frames).map(core::iter::once)
     }

--- a/src/mono/owned.rs
+++ b/src/mono/owned.rs
@@ -262,24 +262,30 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMono<S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert_eq!(channel, 0, "AudioBlockMono only has channel 0");
         self.samples().iter()
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         core::iter::once(self.samples().iter())
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         core::iter::once(&self.data[frame])
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         self.data.iter().take(self.num_frames).map(core::iter::once)
     }
 
@@ -323,7 +329,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMono<S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S> {
         assert_eq!(channel, 0, "AudioBlockMono only has channel 0");
         self.samples_mut().iter_mut()
     }
@@ -331,12 +340,13 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMono<S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         core::iter::once(self.samples_mut().iter_mut())
     }
 
     #[nonblocking]
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(frame < self.num_frames);
         let ptr = &mut self.data[frame] as *mut S;
         // Safety: We're creating a single-item iterator from a valid mutable reference
@@ -344,7 +354,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMono<S> {
     }
 
     #[nonblocking]
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         self.data.iter_mut().take(num_frames).map(core::iter::once)
     }

--- a/src/mono/view.rs
+++ b/src/mono/view.rs
@@ -217,10 +217,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMonoView<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         core::iter::once(self.samples().iter())
     }
 
@@ -231,10 +228,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMonoView<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         self.data.iter().take(self.num_frames).map(core::iter::once)
     }
 

--- a/src/mono/view.rs
+++ b/src/mono/view.rs
@@ -211,24 +211,30 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMonoView<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert_eq!(channel, 0, "AudioBlockMonoView only has channel 0");
         self.samples().iter()
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         core::iter::once(self.samples().iter())
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         core::iter::once(&self.data[frame])
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         self.data.iter().take(self.num_frames).map(core::iter::once)
     }
 

--- a/src/mono/view_mut.rs
+++ b/src/mono/view_mut.rs
@@ -252,10 +252,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMonoViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         core::iter::once(self.samples().iter())
     }
 
@@ -266,10 +263,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMonoViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         self.data.iter().take(self.num_frames).map(core::iter::once)
     }
 
@@ -304,10 +298,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMonoViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S> {
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S> {
         assert_eq!(channel, 0, "AudioBlockMonoViewMut only has channel 0");
         self.samples_mut().iter_mut()
     }
@@ -315,8 +306,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMonoViewMut<'_, S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         core::iter::once(self.samples_mut().iter_mut())
     }
 
@@ -330,8 +320,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMonoViewMut<'_, S> {
     #[nonblocking]
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         self.data.iter_mut().take(num_frames).map(core::iter::once)
     }

--- a/src/mono/view_mut.rs
+++ b/src/mono/view_mut.rs
@@ -246,24 +246,30 @@ impl<S: Sample> AudioBlock<S> for AudioBlockMonoViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert_eq!(channel, 0, "AudioBlockMonoViewMut only has channel 0");
         self.samples().iter()
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         core::iter::once(self.samples().iter())
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         core::iter::once(&self.data[frame])
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         self.data.iter().take(self.num_frames).map(core::iter::once)
     }
 
@@ -298,7 +304,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMonoViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S> {
         assert_eq!(channel, 0, "AudioBlockMonoViewMut only has channel 0");
         self.samples_mut().iter_mut()
     }
@@ -306,19 +315,23 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockMonoViewMut<'_, S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         core::iter::once(self.samples_mut().iter_mut())
     }
 
     #[nonblocking]
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(frame < self.num_frames);
         let ptr = &mut self.data[frame] as *mut S;
         core::iter::once(unsafe { &mut *ptr })
     }
 
     #[nonblocking]
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         self.data.iter_mut().take(num_frames).map(core::iter::once)
     }

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -188,7 +188,7 @@ impl<S: Sample> AudioBlockPlanar<S> {
     ///
     /// Each channel is represented as a slice of samples.
     #[nonblocking]
-    pub fn channels(&self) -> impl Iterator<Item = &[S]> {
+    pub fn channels(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .iter()
             .take(self.num_channels as usize)
@@ -199,7 +199,7 @@ impl<S: Sample> AudioBlockPlanar<S> {
     ///
     /// Each channel is represented as a mutable slice of samples.
     #[nonblocking]
-    pub fn channels_mut(&mut self) -> impl Iterator<Item = &mut [S]> {
+    pub fn channels_mut(&mut self) -> impl ExactSizeIterator<Item = &mut [S]> {
         self.data
             .iter_mut()
             .take(self.num_channels as usize)
@@ -280,7 +280,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         unsafe {
             self.data
@@ -291,7 +291,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
@@ -302,7 +305,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -311,7 +314,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         // Get an immutable slice of the channel boxes: `&[Box<[S]>]`
@@ -375,7 +381,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         unsafe {
             self.data
@@ -388,7 +397,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         self.data
             .iter_mut()
@@ -397,7 +407,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(frame < self.num_frames);
         self.data
             .iter_mut()
@@ -406,7 +416,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let data_slice: &mut [Box<[S]>] = &mut self.data;

--- a/src/planar/owned.rs
+++ b/src/planar/owned.rs
@@ -291,10 +291,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
@@ -314,10 +311,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         // Get an immutable slice of the channel boxes: `&[Box<[S]>]`
@@ -381,10 +375,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S> {
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         unsafe {
             self.data
@@ -397,8 +388,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         self.data
             .iter_mut()
@@ -418,8 +408,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockPlanar<S> {
     #[nonblocking]
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let data_slice: &mut [Box<[S]>] = &mut self.data;

--- a/src/planar/view.rs
+++ b/src/planar/view.rs
@@ -182,10 +182,7 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
@@ -205,10 +202,7 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &'_ S>> {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &'_ S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let data_slice: &[V] = self.data;

--- a/src/planar/view.rs
+++ b/src/planar/view.rs
@@ -106,7 +106,7 @@ impl<'a, S: Sample, V: AsRef<[S]>> AudioBlockPlanarView<'a, S, V> {
     ///
     /// Each channel is represented as a slice of samples.
     #[nonblocking]
-    pub fn channels(&self) -> impl Iterator<Item = &[S]> {
+    pub fn channels(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .iter()
             .take(self.num_channels as usize)
@@ -170,7 +170,7 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         unsafe {
             self.data
@@ -182,7 +182,10 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
@@ -193,7 +196,7 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -202,7 +205,10 @@ impl<S: Sample, V: AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarView<'_, S, V> 
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &'_ S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &'_ S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let data_slice: &[V] = self.data;

--- a/src/planar/view_mut.rs
+++ b/src/planar/view_mut.rs
@@ -119,7 +119,7 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockPlanarViewMut<'a, S, V
     ///
     /// Each channel is represented as a slice of samples.
     #[nonblocking]
-    pub fn channels(&self) -> impl Iterator<Item = &[S]> {
+    pub fn channels(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .iter()
             .take(self.num_channels as usize)
@@ -130,7 +130,7 @@ impl<'a, S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockPlanarViewMut<'a, S, V
     ///
     /// Each channel is represented as a mutable slice of samples.
     #[nonblocking]
-    pub fn channels_mut(&mut self) -> impl Iterator<Item = &mut [S]> {
+    pub fn channels_mut(&mut self) -> impl ExactSizeIterator<Item = &mut [S]> {
         self.data
             .iter_mut()
             .take(self.num_channels as usize)
@@ -208,7 +208,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         unsafe {
             self.data
@@ -220,7 +220,10 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
@@ -231,7 +234,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -240,7 +243,10 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &'_ S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &'_ S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         // `self.data` is the field `&'data [V]`. We get `&'a [V]` from `&'a self`.
@@ -304,7 +310,10 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlana
     }
 
     #[nonblocking]
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         unsafe {
             self.data
@@ -318,7 +327,8 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlana
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         self.data
             .iter_mut()
@@ -327,7 +337,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlana
     }
 
     #[nonblocking]
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(frame < self.num_frames);
         self.data
             .iter_mut()
@@ -336,7 +346,10 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlana
     }
 
     #[nonblocking]
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let data_slice: &mut [V] = self.data;

--- a/src/planar/view_mut.rs
+++ b/src/planar/view_mut.rs
@@ -220,10 +220,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_frames = self.num_frames; // Capture num_frames for the closure
         self.data
             .iter()
@@ -243,10 +240,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlock<S> for AudioBlockPlanarVi
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &'_ S>> {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &'_ S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         // `self.data` is the field `&'data [V]`. We get `&'a [V]` from `&'a self`.
@@ -310,10 +304,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlana
     }
 
     #[nonblocking]
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S> {
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         unsafe {
             self.data
@@ -327,8 +318,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlana
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         self.data
             .iter_mut()
@@ -348,8 +338,7 @@ impl<S: Sample, V: AsMut<[S]> + AsRef<[S]>> AudioBlockMut<S> for AudioBlockPlana
     #[nonblocking]
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let data_slice: &mut [V] = self.data;

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -198,7 +198,7 @@ impl<S: Sample> AudioBlockSequential<S> {
     ///
     /// Each channel is represented as a slice of samples.
     #[nonblocking]
-    pub fn channels(&self) -> impl Iterator<Item = &[S]> {
+    pub fn channels(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .chunks(self.num_frames_allocated)
             .take(self.num_channels as usize)
@@ -209,7 +209,7 @@ impl<S: Sample> AudioBlockSequential<S> {
     ///
     /// Each channel is represented as a mutable slice of samples.
     #[nonblocking]
-    pub fn channels_mut(&mut self) -> impl Iterator<Item = &mut [S]> {
+    pub fn channels_mut(&mut self) -> impl ExactSizeIterator<Item = &mut [S]> {
         self.data
             .chunks_mut(self.num_frames_allocated)
             .take(self.num_channels as usize)
@@ -297,7 +297,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         self.data
             .iter()
@@ -306,7 +306,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
@@ -317,7 +320,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -327,7 +330,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;
@@ -395,7 +401,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         self.data
             .iter_mut()
@@ -406,7 +415,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         let num_frames_allocated = self.num_frames_allocated;
         self.data
@@ -416,7 +426,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(frame < self.num_frames);
         self.data
             .iter_mut()
@@ -426,7 +436,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;

--- a/src/sequential/owned.rs
+++ b/src/sequential/owned.rs
@@ -306,10 +306,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
@@ -330,10 +327,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;
@@ -401,10 +395,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S> {
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         self.data
             .iter_mut()
@@ -415,8 +406,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         let num_frames_allocated = self.num_frames_allocated;
         self.data
@@ -438,8 +428,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequential<S> {
     #[nonblocking]
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -165,7 +165,7 @@ impl<'a, S: Sample> AudioBlockSequentialView<'a, S> {
     ///
     /// Each channel is represented as a slice of samples.
     #[nonblocking]
-    pub fn channels(&self) -> impl Iterator<Item = &[S]> {
+    pub fn channels(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .chunks(self.num_frames_allocated)
             .take(self.num_channels as usize)
@@ -233,7 +233,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         self.data
             .iter()
@@ -242,7 +242,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
@@ -253,7 +256,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -263,7 +266,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;

--- a/src/sequential/view.rs
+++ b/src/sequential/view.rs
@@ -242,10 +242,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
@@ -266,10 +263,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialView<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -292,10 +292,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn channels_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
@@ -316,10 +313,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(
-        &self,
-    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
-    {
+    fn frames_iter(&self) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;
@@ -387,10 +381,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(
-        &mut self,
-        channel: u16,
-    ) -> impl ExactSizeIterator<Item = &mut S> {
+    fn channel_iter_mut(&mut self, channel: u16) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         self.data
             .iter_mut()
@@ -401,8 +392,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         let num_frames_allocated = self.num_frames_allocated;
         self.data
@@ -424,8 +414,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     #[nonblocking]
     fn frames_iter_mut(
         &mut self,
-    ) -> impl '_
-    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
+    ) -> impl ExactSizeIterator<Item = impl ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;

--- a/src/sequential/view_mut.rs
+++ b/src/sequential/view_mut.rs
@@ -184,7 +184,7 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
     ///
     /// Each channel is represented as a slice of samples.
     #[nonblocking]
-    pub fn channels(&self) -> impl Iterator<Item = &[S]> {
+    pub fn channels(&self) -> impl ExactSizeIterator<Item = &[S]> {
         self.data
             .chunks(self.num_frames_allocated)
             .take(self.num_channels as usize)
@@ -195,7 +195,7 @@ impl<'a, S: Sample> AudioBlockSequentialViewMut<'a, S> {
     ///
     /// Each channel is represented as a mutable slice of samples.
     #[nonblocking]
-    pub fn channels_mut(&mut self) -> impl Iterator<Item = &mut [S]> {
+    pub fn channels_mut(&mut self) -> impl ExactSizeIterator<Item = &mut [S]> {
         self.data
             .chunks_mut(self.num_frames_allocated)
             .take(self.num_channels as usize)
@@ -283,7 +283,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter(&self, channel: u16) -> impl Iterator<Item = &S> {
+    fn channel_iter(&self, channel: u16) -> impl ExactSizeIterator<Item = &S> {
         assert!(channel < self.num_channels);
         self.data
             .iter()
@@ -292,7 +292,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channels_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn channels_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_frames = self.num_frames; // Visible frames per channel
         let num_frames_allocated = self.num_frames_allocated; // Allocated frames per channel (chunk size)
 
@@ -303,7 +306,7 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frame_iter(&self, frame: usize) -> impl Iterator<Item = &S> {
+    fn frame_iter(&self, frame: usize) -> impl ExactSizeIterator<Item = &S> {
         assert!(frame < self.num_frames);
         self.data
             .iter()
@@ -313,7 +316,10 @@ impl<S: Sample> AudioBlock<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter(&self) -> impl Iterator<Item = impl Iterator<Item = &S> + '_> + '_ {
+    fn frames_iter(
+        &self,
+    ) -> impl '_ + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &S>>
+    {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;
@@ -381,7 +387,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn channel_iter_mut(&mut self, channel: u16) -> impl Iterator<Item = &mut S> {
+    fn channel_iter_mut(
+        &mut self,
+        channel: u16,
+    ) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(channel < self.num_channels);
         self.data
             .iter_mut()
@@ -392,7 +401,8 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     #[nonblocking]
     fn channels_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_frames = self.num_frames;
         let num_frames_allocated = self.num_frames_allocated;
         self.data
@@ -402,7 +412,7 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frame_iter_mut(&mut self, frame: usize) -> impl Iterator<Item = &mut S> {
+    fn frame_iter_mut(&mut self, frame: usize) -> impl ExactSizeIterator<Item = &mut S> {
         assert!(frame < self.num_frames);
         self.data
             .iter_mut()
@@ -412,7 +422,10 @@ impl<S: Sample> AudioBlockMut<S> for AudioBlockSequentialViewMut<'_, S> {
     }
 
     #[nonblocking]
-    fn frames_iter_mut(&mut self) -> impl Iterator<Item = impl Iterator<Item = &mut S> + '_> + '_ {
+    fn frames_iter_mut(
+        &mut self,
+    ) -> impl '_
+    + ExactSizeIterator<Item = impl '_ + ExactSizeIterator<Item = &mut S>> {
         let num_channels = self.num_channels as usize;
         let num_frames = self.num_frames;
         let stride = self.num_frames_allocated;


### PR DESCRIPTION
Some libraries (eg [clack](https://github.com/prokopyl/clack)) require `ExactSizeIterator`s rather than plain `Iterator`s.  

This change makes all the methods that return `impl Iterator` return `ExactSizeIterator` instead to enable easier interop with these libraries.